### PR TITLE
Add optional CAS integration - Take two

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN pip install pip --upgrade
 # Install project packages
 RUN pip install -r requirements.txt
 RUN pip install -r test_requirements.txt
+RUN pip3 install -r requirements.txt
+RUN pip3 install -r test_requirements.txt
 
 # Add, and run as, non-root user.
 RUN adduser --disabled-password --gecos "" mitodl

--- a/apt.txt
+++ b/apt.txt
@@ -1,5 +1,6 @@
 libpq-dev
 python-pip
+python3-pip
 python-dev
 python3-dev
 npm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ web:
     DATABASE_URL: postgres://postgres@db:5432/postgres
     DEBUG: True
     ALLOWED_HOSTS:
+    LORE_USE_CAS:
+    LORE_ADMIN_EMAIL:
+    LORE_CAS_URL:
   ports:
     - "8070:8070"
   links:

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -86,6 +86,8 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
 )
 
+AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend',)
+
 ROOT_URLCONF = 'lore.urls'
 
 TEMPLATES = [
@@ -155,3 +157,26 @@ STATICFILES_DIRS = (
 COMPRESS_PRECOMPILERS = (
     ('text/requirejs', 'requirejs.RequireJSCompiler'),
 )
+
+# e-mail configurable admins
+ADMIN_EMAIL = get_var('LORE_ADMIN_EMAIL', None)
+if ADMIN_EMAIL is not None:
+    ADMINS = (('Admins', ADMIN_EMAIL),)
+
+CAS_ENABLED = False
+
+# Optional CAS Integration
+if get_var('LORE_USE_CAS', None):
+    CAS_ENABLED = True
+    MIDDLEWARE_CLASSES += ('django_cas_ng.middleware.CASMiddleware',)
+    INSTALLED_APPS += ('django_cas_ng',)
+    AUTHENTICATION_BACKENDS += ('django_cas_ng.backends.CASBackend',)
+    LOGIN_URL = '/login/'
+    LOGIN_REDIRECT_URL = '/'
+    CAS_SERVER_URL = get_var(
+        'LORE_CAS_URL', 'https://auth-r.mitx.mit.edu/login'
+    )
+    CAS_EXTRA_LOGIN_PARAMS = {
+        'provider': 'touchstone',
+        'appname': "LORE"
+    }

--- a/lore/urls.py
+++ b/lore/urls.py
@@ -13,9 +13,16 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
 ]
+
+if settings.CAS_ENABLED:
+    urlpatterns.extend([
+        url(r'^login/$', 'django_cas_ng.views.login', name="login"),
+        url(r'^logout/$', 'django_cas_ng.views.logout', name="logout"),
+    ])

--- a/pylintrc
+++ b/pylintrc
@@ -1,3 +1,7 @@
 [BASIC]
 # Allow django's urlpatterns, and our log preference
 const-rgx = (([A-Z_][A-Z0-9_]*)|(__.*__)|log|urlpatterns)$
+
+[TYPECHECK]
+generated-members =
+    status_code

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ static3==0.5.1
 django-compressor==1.5
 git+https://github.com/bpeschier/django-compressor-requirejs@889d5edc4f2acaa961c170084f1171c700649519#egg=githubdjango-compressor-requirejs-develop
 django-appconf==1.0.1
+git+https://github.com/mingchen/django-cas-ng@69463fe7c23f025be7165c2967f4ceb983d60472#egg=django-cas-ng

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,3 +5,4 @@ pytest-cov
 pytest-django
 git+https://github.com/joeyespo/pytest-watch@cd236e6507e6463a9949d2515391ebe68599ad55#egg=pytest-watch-poll
 mock
+urltools

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,18 +1,34 @@
 """
 Validate that our settings functions work, and we can create yaml files
 """
+import imp
 import os
+import sys
 import tempfile
-import unittest
 
+from django.conf import settings
+from django.core import mail
+from django.test import TestCase
 import mock
 import yaml
 
 from lore.settings import load_fallback, get_var
 
 
-class TestSettings(unittest.TestCase):
+class TestSettings(TestCase):
     """Validate that settings work as expected."""
+
+    def reload_settings(self):
+        """
+        Reload settings module with cleanup to restore it.
+
+        Returns:
+            dict: dictionary of the newly reloaded settings ``vars``
+        """
+        imp.reload(sys.modules['lore.settings'])
+        # Restore settings to original settings after test
+        self.addCleanup(imp.reload, sys.modules['lore.settings'])
+        return vars(sys.modules['lore.settings'])
 
     def test_load_fallback(self):
         """Verify our YAML load works as expected."""
@@ -27,11 +43,14 @@ class TestSettings(unittest.TestCase):
             fallback_config = load_fallback()
             self.assertDictEqual(fallback_config, config_settings)
 
-    @mock.patch.dict('lore.settings.FALLBACK_CONFIG', {'FOO': 'bar'})
     def test_get_var(self):
         """Verify that get_var does the right thing with precedence"""
-        # Verify fallback
-        self.assertEqual(get_var('FOO', 'notbar'), 'bar')
+        with mock.patch.dict(
+            'lore.settings.FALLBACK_CONFIG',
+            {'FOO': 'bar'}
+        ):
+            # Verify fallback
+            self.assertEqual(get_var('FOO', 'notbar'), 'bar')
 
         # Verify default value
         self.assertEqual(get_var('NOTATHING', 'foobar'), 'foobar')
@@ -59,3 +78,60 @@ class TestSettings(unittest.TestCase):
             {'BLAH': True}
         ):
             self.assertEqual(get_var('BLAH', False), True)
+
+    def test_cas_settings(self,):
+        """Verify CAS settings get set correctly"""
+        with mock.patch.dict('os.environ', {
+            'LORE_USE_CAS': 'yep',
+            'LORE_CAS_URL': 'foobar'
+        }, clear=True):
+            settings_vars = self.reload_settings()
+            self.assertTrue(
+                set(dict(
+                    CAS_ENABLED=True,
+                    LOGIN_URL='/login/',
+                    LOGIN_REDIRECT_URL='/',
+                    CAS_SERVER_URL='foobar'
+                )).issubset(set(settings_vars))
+            )
+            self.assertDictEqual(
+                {
+                    'provider': 'touchstone',
+                    'appname': "LORE"
+                },
+                settings_vars['CAS_EXTRA_LOGIN_PARAMS']
+            )
+            self.assertIn(
+                'django_cas_ng.middleware.CASMiddleware',
+                settings_vars['MIDDLEWARE_CLASSES']
+            )
+            self.assertIn(
+                'django_cas_ng.backends.CASBackend',
+                settings_vars['AUTHENTICATION_BACKENDS']
+            )
+            self.assertIn('django_cas_ng', settings_vars['INSTALLED_APPS'])
+
+        # Test settings with CAS disabled
+        with mock.patch.dict('os.environ', {
+            'LORE_USE_CAS': '',
+            'LORE_CAS_URL': 'foobar'
+        }, clear=True):
+            settings_vars = self.reload_settings()
+            self.assertFalse(settings_vars['CAS_ENABLED'])
+
+    def test_admin_settings(self):
+        """Verify that we configure email with environment variable"""
+        test_admin_email = 'cuddle_bunnies@example.com'
+        with mock.patch.dict('os.environ', {
+            'LORE_ADMIN_EMAIL': test_admin_email,
+        }, clear=True):
+            settings_vars = self.reload_settings()
+            self.assertEqual(
+                (('Admins', test_admin_email),),
+                settings_vars['ADMINS']
+            )
+        # Manually set ADMIN to our test setting and verify e-mail
+        # goes where we expect
+        settings.ADMINS = (('Admins', test_admin_email),)
+        mail.mail_admins('Test', 'message')
+        self.assertIn(test_admin_email, mail.outbox[0].to)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,55 @@
+"""
+Testing of project level URLs.
+"""
+
+import imp
+import sys
+
+from django.conf import settings
+from django.test import TestCase
+from django.test.client import RedirectCycleError
+from django.utils.importlib import import_module
+from urltools import compare
+
+
+def reload_url_conf():
+    """Reloads URLs when they are changed by settings"""
+    if settings.ROOT_URLCONF in sys.modules:
+        imp.reload(sys.modules[settings.ROOT_URLCONF])
+    import_module(settings.ROOT_URLCONF)
+
+
+class TestURLs(TestCase):
+    """Verify project level URL configuration."""
+
+    def test_cas_enabled(self):
+        """Verify that CAS is wired up properly when enabled"""
+        with self.settings(
+            CAS_ENABLED=True,
+            CAS_SERVER_URL='http://example.com/login',
+            CAS_EXTRA_LOGIN_PARAMS={
+                'provider': 'touchstone',
+                'appname': "LORE"
+            }
+        ):
+            reload_url_conf()
+            # Because this won't actually work, we get in a redirect
+            # loop, or at least, best as I can tell.
+            with self.assertRaises(RedirectCycleError) as context_manager:
+                self.client.get('/login/', follow=True)
+            exception = context_manager.exception
+            self.assertTrue(compare(
+                'http://example.com/login/?appname=LORE&'
+                'service=http%3A%2F%2Fexample.com%2Flogin%2F%3Fnext%3D%252F'
+                '&provider=touchstone',
+                exception.last_response['location']
+            ))
+
+    def test_cas_disable(self):
+        """Verify that when CAS is disabled, login is default"""
+        with self.settings(
+            CAS_ENABLED=False
+        ):
+            reload_url_conf()
+            response = self.client.get('/login', follow=True)
+            self.assertEqual(404, response.status_code)


### PR DESCRIPTION
Add ADMIN e-mail configuration
Closes #16
[finished #94639216]

We can wait until https://github.com/mingchen/django-cas-ng/pull/34 merges and point at their repo, or use this as is.
