### PR TITLE
Redirect to Listing page after Respository creation.

### DIFF
--- a/learningresources/tests/test_views.py
+++ b/learningresources/tests/test_views.py
@@ -34,7 +34,7 @@ class TestViews(LoreTestCase):
         body = resp.content.decode("utf-8")
         self.assertTrue(repo_name in body)
         # Should have been redirected to the welcome page.
-        self.assertTrue("Welcome" in body)
+        self.assertTrue("Repository {0}".format(repo_name) in body)
 
     def test_listing_unauthorized(self):
         """View listing page."""

--- a/learningresources/views.py
+++ b/learningresources/views.py
@@ -41,8 +41,8 @@ def create_repo(request):
     if request.method == "POST":
         form = RepositoryForm(data=request.POST)
         if form.is_valid():
-            form.save(request.user)
-            return redirect(reverse("welcome"))
+            repo = form.save(request.user)
+            return redirect(reverse("listing", args=(repo.id, 1)))
     return render(
         request,
         "create_repo.html",


### PR DESCRIPTION
closes #76.

It used to redirect back to the Welcome page.
