### PR TITLE
Add support for Postgresql client

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -15,3 +15,7 @@ nodejs
 libxml2-dev
 libxslt1-dev
 libxslt1.1
+
+# developer requirements
+postgresql-client
+


### PR DESCRIPTION
Add support for Postgresql client in docker container. This change
allows this command to open the Postgres command line client:

`docker-compose run web python manage.py dbshell`

Closes #72
