### PR TITLE
Support running celery in Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: uwsgi uwsgi.ini
+worker: celery -A lore worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,10 @@ web:
     PORT: 8070
     DATABASE_URL: postgres://postgres@db:5432/postgres
     ALLOWED_HOSTS:
-    BROKER_URL: redis://redis:6379/4
     LORE_USE_CAS:
     LORE_ADMIN_EMAIL:
     LORE_CAS_URL:
-    PYTHONPATH: /src
-    DJANGO_SETTINGS_MODULE: lore.settings
+    USE_CELERY: True
   ports:
     - "8070:8070"
   links:
@@ -47,13 +45,8 @@ celery:
     LORE_LOG_LEVEL: DEBUG
     DJANGO_LOG_LEVEL: INFO
     DATABASE_URL: postgres://postgres@db:5432/postgres
-    ALLOWED_HOSTS:
     BROKER_URL: redis://redis:6379/4
-    LORE_USE_CAS:
-    LORE_ADMIN_EMAIL:
-    LORE_CAS_URL:
-    PYTHONPATH: /src
-    DJANGO_SETTINGS_MODULE: lore.settings
+    CELERY_RESULT_BACKEND: redis://redis:6379/4
   links:
     - db
     - redis

--- a/lore/celery.py
+++ b/lore/celery.py
@@ -4,9 +4,13 @@ http://celery.readthedocs.org/en/latest/django/first-steps-with-django.html
 """
 from __future__ import absolute_import
 
+import os
 import logging
 
 from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'lore.settings')
+
 from django.conf import settings
 
 log = logging.getLogger(__name__)

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -254,5 +254,8 @@ LOGGING = {
 }
 
 # Celery
-BROKER_URL = get_var("BROKER_URL", None)
-USE_CELERY = get_var("USE_CELERY", "True")
+BROKER_URL = get_var("BROKER_URL", get_var("REDISCLOUD_URL", None))
+CELERY_RESULT_BACKEND = get_var(
+    "CELERY_RESULT_BACKEND", get_var("REDISCLOUD_URL", None)
+)
+USE_CELERY = get_var("USE_CELERY", False)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,5 @@
 addopts = --cov . --cov-config .coveragerc --pep8 --pylint --cov-report term --cov-report html --ds=lore.settings
 pep8ignore =
     */migrations/* ALL
-    */docs/conf.py ALL
+    docs/conf.py ALL
+    lore/celery.py E402


### PR DESCRIPTION
This gets the worker going on Heroku, so it partially resolves #109 , but because they do not share storage with the upload, the worker fails to find the tar.gz and isn't usable until we integrate Django storages.  We can merge this here as is, which would be my preference, and create another story to add django-storages support for course uploads (with a default to local /tmp for dev/docker, and configurable to use S3), or I can solve that issue here.

@pdpinch and @Ferdi, thoughts?
