### PR TITLE
Properly handle export when things go wrong.

### DIFF
--- a/importer/tests/test_import.py
+++ b/importer/tests/test_import.py
@@ -48,20 +48,28 @@ class TestImportToy(LoreTestCase):
         """
         Simplest possible test.
         """
-        self.assertTrue(get_resources(self.repo.id).count() == 0)
-        self.assertTrue(Course.objects.count() == 0)
+        resource_count = get_resources(self.repo.id).count()
+        course_count = Course.objects.count()
         import_course_from_file(self.course_zip, self.repo.id, self.user.id)
-        self.assertTrue(get_resources(self.repo.id).count() == 5)
-        self.assertTrue(Course.objects.count() == 1)
+        self.assertEqual(
+            get_resources(self.repo.id).count(),
+            resource_count + 5)
+        self.assertEqual(
+            Course.objects.count(),
+            course_count + 1,
+        )
 
     def test_import_multiple(self):
         """
         Simplest possible test.
         """
-        self.assertTrue(Course.objects.count() == 0)
+        original_count = Course.objects.count()
         import_course_from_file(
             self.get_course_multiple_zip(), self.repo.id, self.user.id)
-        self.assertTrue(Course.objects.count() == 2)
+        self.assertEqual(
+            Course.objects.count(),
+            original_count + 2,
+        )
 
     def test_invalid_file(self):
         """Invalid zip file"""
@@ -82,16 +90,22 @@ class TestImportToy(LoreTestCase):
         """
         Single course (course.xml in root of archive).
         """
-        self.assertTrue(Course.objects.count() == 0)
+        original_count = Course.objects.count()
         import_course_from_file(
             self.get_course_single_tarball(), self.repo.id, self.user.id)
-        self.assertTrue(Course.objects.count() == 1)
+        self.assertEqual(
+            Course.objects.count(),
+            original_count + 1,
+        )
 
     def test_import_task(self):
         """
         Copy of test_import_single that just exercises tasks.py.
         """
-        self.assertTrue(Course.objects.count() == 0)
+        original_count = Course.objects.count()
         import_file(
             self.get_course_single_tarball(), self.repo.id, self.user.id)
-        self.assertTrue(Course.objects.count() == 1)
+        self.assertEqual(
+            Course.objects.count(),
+            original_count + 1,
+        )

--- a/importer/tests/test_views.py
+++ b/importer/tests/test_views.py
@@ -126,19 +126,22 @@ class TestViews(LoreTestCase):
 
     def test_upload_post(self):
         """POST upload page."""
-        self.assertTrue(LearningResource.objects.count() == 0)
+        original_count = LearningResource.objects.count()
         body = self.upload_test_file()
-        self.assertTrue(LearningResource.objects.count() == 5)
+        self.assertEqual(
+            LearningResource.objects.count(),
+            original_count + 5,
+        )
         # We should have been redirected to the Listing page.
         self.assertTrue('Listing</title>' in body)
 
     def test_upload_duplicate(self):
         """Gracefully inform the user."""
-        self.assertTrue(Course.objects.count() == 0)
+        original_count = Course.objects.count()
         self.upload_test_file()
-        self.assertTrue(Course.objects.count() == 1)
+        self.assertTrue(Course.objects.count() == original_count + 1)
         self.upload_test_file()
-        self.assertTrue(Course.objects.count() == 1)
+        self.assertTrue(Course.objects.count() == original_count + 1)
 
     def upload_test_file(self):
         """Used multiple times in tests"""

--- a/learningresources/tests/base.py
+++ b/learningresources/tests/base.py
@@ -15,7 +15,7 @@ from django.test import Client
 from django.test.testcases import TestCase
 import haystack
 
-from learningresources.api import create_repo
+from learningresources.api import create_repo, create_course, create_resource
 from learningresources.models import Repository
 from roles.api import assign_user_to_repo_group
 from roles.permissions import GroupTypes
@@ -67,6 +67,22 @@ class LoreTestCase(TestCase):
             description="just a test",
             user_id=self.user.id,
         )
+        self.course = create_course(
+            org="test org",
+            repo_id=self.repo.id,
+            course_number="infinity",
+            run="Febtober",
+            user_id=self.user.id,
+        )
+        self.resource = create_resource(
+            course=self.course,
+            parent=None,
+            resource_type="example",
+            title="silly example",
+            content_xml="<blah>blah</blah>",
+            mpath="/blah",
+        )
+
         assign_user_to_repo_group(
             self.user,
             self.repo,

--- a/learningresources/tests/test_forms.py
+++ b/learningresources/tests/test_forms.py
@@ -29,6 +29,6 @@ class TestCourseForm(LoreTestCase):
         }
         form = CourseForm(data)
         self.assertTrue(form.is_valid())
-        self.assertTrue(Course.objects.count() == 0)
+        original_count = Course.objects.count()
         form.save(self.user)
-        self.assertTrue(Course.objects.count() == 1)
+        self.assertTrue(Course.objects.count() == original_count + 1)


### PR DESCRIPTION
If the user has no permission or the resource doesn't exist, return
a 404.

Note: Although the `export` view previously appeared to have no
permissions checking, it did because the `get_resource` API function
would raise a 403 response for bad permissions.

This commit improves the codebase by moving HTTP response raising from
the API to the views, as is proper.

closes #172 

Reading order suggestion:
1. The primary work was done in `learningresources/tests/test_views.py`, so that should be read first
2. Objects for testing were added to `learningresources/tests/base.py`
3. The actual fix is in `learningresources/api.py` and `ui/views.py`
4. The rest are updates to the tests after adding the testing objects to `base.py`
