### PR TITLE
Update tox version & version lock for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 env:
   - DATABASE_URL=postgres://postgres@localhost:5432/postgres
 install:
-  - pip install tox
+  - pip install tox==2.0.2
   - pip install coveralls
 script: 
   - tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ psycopg2==2.6
 PyYAML==3.11
 redis==2.10.3
 static3==0.5.1
-tox==1.9.2
+tox==2.0.2
 uwsgi==2.0.10
 
 # django guardian branch that fixed bug in master


### PR DESCRIPTION
While using `tox 1.9.2`, the `envlist` override was not working, so the `testenv:docs` tox environment failed to build because `alabaster` (sphinx dependency) requires Python 2.7, but Python 3.4 was being used for the virtual environment instead.

The build [has not been failing on travis](https://travis-ci.org/mitodl/lore/builds/66964703) because tox was not version locked for travis builds. This change just updates the version of tox to fix local doc builds, as well as lock the version of tox running on travis to prevent build failure inconsistency in the future.
