### PR TITLE
Bugfixes for tox 2.0+ changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ python:
 env:
   - DATABASE_URL=postgres://postgres@localhost:5432/postgres
 install:
-  - pip install tox==2.0.2
+  - "pip install 'tox>=2.0.2,<3.0.0'"
   - pip install coveralls
 script: 
   - tox
-  - tox -e docs
 after_success: coveralls
 deploy:
   provider: heroku

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ psycopg2==2.6
 PyYAML==3.11
 redis==2.10.3
 static3==0.5.1
-tox==2.0.2
+tox>=2.0.2,<3.0.0
 uwsgi==2.0.10
 
 # django guardian branch that fixed bug in master

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py33,py34,docs
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -8,12 +8,13 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
 commands = py.test {posargs}
-setenv = 
+passenv = *
+setenv =
     CELERY_ALWAYS_EAGER=True
 
 [testenv:docs]
-envlist = py27
-changedir=docs
+basepython = python2.7
+changedir = docs
 
 deps=
     -r{toxinidir}/doc_requirements.txt


### PR DESCRIPTION
- Using tox >= 2.0, <3.0.0
- Pass all environment variables
- Change docs to use python2.7 explicitly
