### PR TITLE
Fixes indexing so it's possible to search on content_xml.

### DIFF
--- a/search/search_indexes.py
+++ b/search/search_indexes.py
@@ -4,6 +4,8 @@ Index information for Haystack.
 http://django-haystack.readthedocs.org/en/latest/tutorial.html
 """
 
+from __future__ import unicode_literals
+
 from haystack import indexes
 
 from learningresources.models import LearningResource
@@ -13,8 +15,7 @@ class LearningResourceIndex(indexes.SearchIndex, indexes.Indexable):
     """
     Index configuration for the LearningResource model.
     """
-    text = indexes.CharField(
-        document=True, model_attr="content_xml", use_template=True)
+    text = indexes.CharField(document=True)
     resource_type = indexes.CharField(
         model_attr="learning_resource_type",
         faceted=True,
@@ -29,6 +30,12 @@ class LearningResourceIndex(indexes.SearchIndex, indexes.Indexable):
     def index_queryset(self, using=None):
         """Records to check when updating entire index."""
         return self.get_model().objects.all()
+
+    def prepare_text(self, obj):  # pylint: disable=no-self-use
+        """Indexing of the primary content of a LearningResource."""
+        return "{0} {1} {2}".format(
+            obj.title, obj.description, obj.content_xml,
+        )
 
     def prepare_run(self, obj):  # pylint: disable=no-self-use
         """Define what goes into the "run" index."""

--- a/ui/templates/search/indexes/learningresources/learningresource_text.txt
+++ b/ui/templates/search/indexes/learningresources/learningresource_text.txt
@@ -1,6 +1,0 @@
-{{ object.title }}
-{{ object.description }}
-{{ object.LearningResourceType.name }}
-{{ object.Course.course_number }}
-{{ object.Course.Repository.name }}
-{{ object.Course.Repository.id }}


### PR DESCRIPTION
The `model_attr` kwarg is ignored when `use_template` is used. If using a
template, all fields must be specified in the template.

Upon review, it seems that the complication of using a template was unnecessary,
because the template was so simple that having it separated the indexing
definitions unnecessarily into multiple locations.

Moves definition of `content_xml` into search_indexes.py with the definition
for all other fields.

Adds `content_xml` to the fields being indexed.

Removes repository name and ID from indexing (never should have been there).

resolves #197 
