### PR TITLE
Fixed IntegrityError when 'required' attribute is missing from Vocabulary

### DIFF
--- a/rest/serializers.py
+++ b/rest/serializers.py
@@ -14,7 +14,7 @@ from rest_framework.generics import get_object_or_404
 
 from taxonomy.models import Vocabulary, Term
 from learningresources.models import Repository
-from .util import LambdaDefault
+from .util import LambdaDefault, RequiredBooleanField
 
 
 class RepositorySerializer(ModelSerializer):
@@ -50,6 +50,10 @@ class VocabularySerializer(ModelSerializer):
             Repository, slug=context['view'].kwargs['repo_slug']
         )
     ))
+
+    # django-rest-framework mistakenly assumes required=False
+    # unless we override the behavior
+    required = RequiredBooleanField()
 
     class Meta:
         # pylint: disable=missing-docstring

--- a/rest/tests/test_rest.py
+++ b/rest/tests/test_rest.py
@@ -178,6 +178,15 @@ class TestRest(RESTTestCase):
         self.get_vocabulary("missing", "missing",
                             expected_status=HTTP_404_NOT_FOUND)
 
+        # test create with missing required
+        dict_missing_required = dict(input_dict)
+        del dict_missing_required['required']
+        dict_missing_required['name'] = 'new name'
+
+        # we should get a 400 error for validation
+        self.create_vocabulary(self.repo.slug, dict_missing_required,
+                               expected_status=HTTP_400_BAD_REQUEST)
+
         # as anonymous
         self.logout()
         self.get_vocabularies("missing", expected_status=HTTP_403_FORBIDDEN)

--- a/rest/util.py
+++ b/rest/util.py
@@ -4,6 +4,8 @@ Utility functions and classes for REST app
 
 from __future__ import unicode_literals
 
+from rest_framework.fields import BooleanField, empty
+
 
 class LambdaDefault(object):
     """
@@ -23,3 +25,12 @@ class LambdaDefault(object):
     def __call__(self):
         """Pass context to function which contains view and request"""
         return self.func(self.context)
+
+
+class RequiredBooleanField(BooleanField):
+    """Override Django REST Framework behavior where BooleanField is coerced
+    to False even if required=True and value is missing from request"""
+
+    def get_value(self, dictionary):
+        """Override get_value to skip incorrect html.is_html_input check"""
+        return dictionary.get(self.field_name, empty)


### PR DESCRIPTION
Django REST framework doesn't seem to enforce the `required` field correctly for `BooleanField`. This PR overrides the `BooleanField` to skip a check with `rest_framework.utils.html.is_html_input`. That function assumes that if the data passed in is a MultiDict type datastructure, that means the data came from an HTML form, which isn't true for the test below.
