### PR TITLE
Adds abstract base model to contain audit fields.

### DIFF
--- a/audit/models.py
+++ b/audit/models.py
@@ -1,0 +1,13 @@
+"""A base class for all models with audit fields."""
+
+from django.db import models
+
+
+class BaseModel(models.Model):
+    """A models.Model with audit fields."""
+    date_created = models.DateTimeField(auto_now_add=True)
+    date_modified = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        """Do not create a database table for BaseModel."""
+        abstract = True

--- a/learningresources/api.py
+++ b/learningresources/api.py
@@ -54,7 +54,7 @@ def create_course(org, repo_id, course_number, run, user_id):
 
     """
     # Check on unique values before attempting a get_or_create, because
-    # items such as import_date will always make it non-unique.
+    # items such as date_created  will always make it non-unique.
     unique = {
         "org": org, "course_number": course_number, "run": run,
         "repository_id": repo_id,

--- a/learningresources/migrations/0005_auto_adds_audit_fields.py
+++ b/learningresources/migrations/0005_auto_adds_audit_fields.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import datetime
+
+from django.db import models, migrations
+from django.utils.timezone import utc
+
+# pylint: skip-file
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0004_static_assets'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='course',
+            name='date_created',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 19, 114680, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='date_modified',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 20, 410676, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='learningresource',
+            name='date_created',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 21, 522626, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='learningresource',
+            name='date_modified',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 22, 770622, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='learningresourcetype',
+            name='date_created',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 24, 114723, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='learningresourcetype',
+            name='date_modified',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 25, 402653, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='repository',
+            name='date_created',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 26, 858744, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='repository',
+            name='date_modified',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 28, 170661, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='staticasset',
+            name='date_created',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 21, 11, 38, 480507, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='staticasset',
+            name='date_modified',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 21, 11, 42, 9869, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+    ]

--- a/learningresources/migrations/0006_move_datestamp_data.py
+++ b/learningresources/migrations/0006_move_datestamp_data.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.db.models import F
+
+# pylint: skip-file
+
+
+def transfer_datetimes(apps, schema_editor):
+    """Move the added/edited stamps to the new, universal fields."""
+    Course = apps.get_model("learningresources", "Course")
+    Course.objects.all().update(date_created=F("import_date"))
+
+    Repository = apps.get_model("learningresources", "Repository")
+    Repository.objects.all().update(date_created=F("create_date"))
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0005_auto_adds_audit_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(transfer_datetimes)
+    ]

--- a/learningresources/migrations/0007_remove_old_date_fields.py
+++ b/learningresources/migrations/0007_remove_old_date_fields.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+# pylint: skip-file
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0006_move_datestamp_data'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='course',
+            name='import_date',
+        ),
+        migrations.RemoveField(
+            model_name='repository',
+            name='create_date',
+        ),
+    ]

--- a/learningresources/models.py
+++ b/learningresources/models.py
@@ -13,6 +13,7 @@ from django.utils.text import slugify
 from django.utils.encoding import python_2_unicode_compatible
 from django.shortcuts import get_object_or_404
 
+from audit.models import BaseModel
 from roles.api import roles_init_new_repo, roles_update_repo
 from roles.permissions import RepoPermission
 
@@ -40,7 +41,7 @@ def static_asset_basepath(asset, filename):
     )
 
 
-class Course(models.Model):
+class Course(BaseModel):
     """
     A course on edX platform (MITx or residential).
     """
@@ -48,7 +49,6 @@ class Course(models.Model):
     org = models.TextField()
     course_number = models.TextField()
     run = models.TextField()
-    import_date = models.DateField(auto_now_add=True)
     imported_by = models.ForeignKey(User)
 
     class Meta:
@@ -56,7 +56,7 @@ class Course(models.Model):
         unique_together = ("repository", "org", "course_number", "run")
 
 
-class StaticAsset(models.Model):
+class StaticAsset(BaseModel):
     """
     Holds static assets for a course (css, html, javascript, images, etc)
     """
@@ -65,7 +65,7 @@ class StaticAsset(models.Model):
     asset = models.FileField(upload_to=static_asset_basepath)
 
 
-class LearningResource(models.Model):
+class LearningResource(BaseModel):
     """
     The units that compose an edX course:
     chapter, sequential, vertical, problem, video, html, etc.
@@ -88,7 +88,7 @@ class LearningResource(models.Model):
 
 
 @python_2_unicode_compatible
-class LearningResourceType(models.Model):
+class LearningResourceType(BaseModel):
     """
     Learning resource type:
     chapter, sequential, vertical, problem, video, html, etc.
@@ -99,7 +99,7 @@ class LearningResourceType(models.Model):
         return self.name
 
 
-class Repository(models.Model):
+class Repository(BaseModel):
     """
     A collection of learning resources
     that come from (usually tightly-related) courses.
@@ -107,7 +107,6 @@ class Repository(models.Model):
     name = models.CharField(max_length=256, unique=True)
     slug = models.SlugField(max_length=256, unique=True)
     description = models.TextField()
-    create_date = models.DateField(auto_now_add=True)
     created_by = models.ForeignKey(User)
 
     @transaction.atomic

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -85,6 +85,7 @@ INSTALLED_APPS = (
     'compressor',
     'bootstrap3',
     'guardian',
+    'audit',
     'learningresources',
     'importer',
     'ui',

--- a/rest/serializers.py
+++ b/rest/serializers.py
@@ -32,13 +32,13 @@ class RepositorySerializer(ModelSerializer):
             'slug',
             'name',
             'description',
-            'create_date',
+            'date_created',
             'created_by',
         )
         read_only_fields = (
             'id',
             'slug',
-            'create_date',
+            'date_created',
         )
 
 

--- a/rest/tests/test_rest.py
+++ b/rest/tests/test_rest.py
@@ -483,7 +483,7 @@ class TestRest(RESTTestCase):
             'slug': 'sluggy',
             'name': 'other name',
             'description': 'description',
-            'create_date': "2015-01-01",
+            'date_created': "2015-01-01",
             'created_by': self.user_norepo.id,
         }
         result = self.create_repository(repo_dict, skip_assert=True)
@@ -491,7 +491,7 @@ class TestRest(RESTTestCase):
         # the serializer
         self.assertNotEqual(repo_dict['id'], result['id'])
         self.assertNotEqual(repo_dict['slug'], result['slug'])
-        self.assertNotEqual(repo_dict['create_date'], result['create_date'])
+        self.assertNotEqual(repo_dict['date_created'], result['date_created'])
         self.assertNotIn('created_by', result)
         repository = Repository.objects.get(slug=result['slug'])
         self.assertEqual(repository.created_by.id, self.user.id)

--- a/taxonomy/migrations/0005_adds_audit_fields.py
+++ b/taxonomy/migrations/0005_adds_audit_fields.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import datetime
+
+from django.db import models, migrations
+from django.utils.timezone import utc
+
+# pylint: skip-file
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taxonomy', '0004_finish_slug'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='term',
+            name='date_created',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 29, 506705, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='term',
+            name='date_modified',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 31, 650700, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='vocabulary',
+            name='date_created',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 33, 42693, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='vocabulary',
+            name='date_modified',
+            field=models.DateTimeField(default=datetime.datetime(2015, 6, 24, 18, 19, 34, 210680, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+    ]

--- a/taxonomy/models.py
+++ b/taxonomy/models.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.text import slugify
 from django.shortcuts import get_object_or_404
 
+from audit.models import BaseModel
 from learningresources.models import (
     Repository,
     LearningResourceType,
@@ -13,7 +14,7 @@ from learningresources.models import (
 )
 
 
-class Vocabulary(models.Model):
+class Vocabulary(BaseModel):
     """Model for vocabulary table"""
     MANAGED = "m"
     FREE_TAGGING = "f"
@@ -60,7 +61,7 @@ class Vocabulary(models.Model):
         return super(Vocabulary, self).save(*args, **kwargs)
 
 
-class Term(models.Model):
+class Term(BaseModel):
     """Model for term table"""
     vocabulary = models.ForeignKey(Vocabulary, on_delete=models.PROTECT)
     label = models.CharField(max_length=256)


### PR DESCRIPTION
Closes #134

Adds datetime fields for created and modified dates.

Removes older `auto_now_add` fields with inconsistent names in favor of the universal ones. Contains schema and data migrations to support this.
