### PR TITLE
Removed duplicate ManyToMany field

### DIFF
--- a/learningresources/migrations/0008_remove_staticasset_learning_resources.py
+++ b/learningresources/migrations/0008_remove_staticasset_learning_resources.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+# pylint: skip-file
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0007_remove_old_date_fields'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='staticasset',
+            name='learning_resources',
+        ),
+    ]

--- a/learningresources/models.py
+++ b/learningresources/models.py
@@ -61,7 +61,6 @@ class StaticAsset(BaseModel):
     Holds static assets for a course (css, html, javascript, images, etc)
     """
     course = models.ForeignKey(Course)
-    learning_resources = models.ManyToManyField('LearningResource', blank=True)
     asset = models.FileField(upload_to=static_asset_basepath)
 
 


### PR DESCRIPTION
Since both `LearningResource` and `StaticAsset` have a `ManyToMany` field there are two database tables covering the same relation.
