### PR TITLE
Renamed 'Copy to Clipboard' to 'Select Text'

### DIFF
--- a/ui/static/ui/js/listing.js
+++ b/ui/static/ui/js/listing.js
@@ -26,7 +26,7 @@ define(['jquery', 'bootstrap', 'icheck', 'csrf'], function(jQuery) {
       $('.cd-panel').addClass('is-visible');
     });
 
-    // Handle "Copy to Clipboard"
+    // Handle "Select XML"
     $('.cd-panel #copy-textarea-xml').on('click', function(event) {
       event.preventDefault();
       $('.cd-panel .textarea-xml').select();

--- a/ui/templates/includes/resource_panel.html
+++ b/ui/templates/includes/resource_panel.html
@@ -18,7 +18,7 @@
             <textarea class="form-control textarea-xml">
             </textarea>
             <p class="text-right">
-              <a id="copy-textarea-xml" href="#" class="btn btn-white">Copy to Clipboard</a>
+              <a id="copy-textarea-xml" href="#" class="btn btn-white">Select XML</a>
             </p>
           </form>
         </div>


### PR DESCRIPTION
Since copy to clipboard functionality isn't on the roadmap we should rename this button to better set user expectations
