### PR TITLE
Added ability to filter vocabularies by learning resource type

### DIFF
--- a/rest/tests/test_rest.py
+++ b/rest/tests/test_rest.py
@@ -11,7 +11,10 @@ from rest_framework.status import (
     HTTP_405_METHOD_NOT_ALLOWED,
 )
 
-from learningresources.models import Repository
+from learningresources.models import (
+    Repository,
+    LearningResourceType,
+)
 from taxonomy.models import Vocabulary, Term
 
 from rest.serializers import (
@@ -261,6 +264,44 @@ class TestRest(RESTTestCase):
         self.get_vocabulary(
             other_repo_dict['slug'], vocab2_dict['slug']
         )
+
+    def test_vocabulary_filter_type(self):
+        """Test filtering learning resource types for vocabularies"""
+        self.create_vocabulary(self.repo.slug)
+
+        learning_resource_type = LearningResourceType.objects.first()
+
+        # in the future this should be handled within the API
+        Vocabulary.objects.first().learning_resource_types.add(
+            learning_resource_type
+        )
+
+        resp = self.client.get("{repo_base}{repo_slug}/vocabularies/".format(
+            repo_base=REPO_BASE,
+            repo_slug=self.repo.slug,
+        ))
+        self.assertEqual(resp.status_code, HTTP_200_OK)
+        self.assertEqual(1, as_json(resp)['count'])
+
+        resp = self.client.get(
+            "{repo_base}{repo_slug}"
+            "/vocabularies/?type_name={name}".format(
+                repo_base=REPO_BASE,
+                repo_slug=self.repo.slug,
+                name=learning_resource_type.name,
+            ))
+        self.assertEqual(resp.status_code, HTTP_200_OK)
+        self.assertEqual(1, as_json(resp)['count'])
+
+        resp = self.client.get(
+            "{repo_base}{repo_slug}"
+            "/vocabularies/?type_name={name}".format(
+                repo_base=REPO_BASE,
+                repo_slug=self.repo.slug,
+                name="missing",
+            ))
+        self.assertEqual(resp.status_code, HTTP_200_OK)
+        self.assertEqual(0, as_json(resp)['count'])
 
     def test_term(self):
         """Test REST access for term"""

--- a/rest/views.py
+++ b/rest/views.py
@@ -42,6 +42,7 @@ from rest.permissions import (
 )
 from rest.util import CheckValidMemberParamMixin
 from learningresources.models import Repository
+from taxonomy.models import Vocabulary
 from learningresources.api import (
     get_repos,
 )
@@ -104,9 +105,17 @@ class VocabularyList(ListCreateAPIView):
     )
 
     def get_queryset(self):
-        """Filter to vocabularies for a repository"""
-        return Repository.objects.get(
-            slug=self.kwargs['repo_slug']).vocabulary_set.order_by('id')
+        """Filter vocabularies by repository ownership and optionally
+        by learning resource type"""
+        queryset = Vocabulary.objects.filter(
+            repository__slug=self.kwargs['repo_slug']
+        )
+        learning_resource_type = self.request.query_params.get(
+            'type_name', None)
+        if learning_resource_type is not None:
+            queryset = queryset.filter(
+                learning_resource_types__name=learning_resource_type)
+        return queryset.order_by('id')
 
     def get_success_headers(self, data):
         """Add Location header for model create"""


### PR DESCRIPTION
This adds the ability to filter vocabularies by learning resource types, for example "/api/v1/repositories/repo_slug/vocabularies/?learning_resource_type=chapter"
