### PR TITLE
Add link to request create repository permission

### DIFF
--- a/lore/settings.py
+++ b/lore/settings.py
@@ -225,6 +225,7 @@ EMAIL_PORT = get_var('LORE_EMAIL_PORT', 25)
 EMAIL_HOST_USER = get_var('LORE_EMAIL_USER', '')
 EMAIL_HOST_PASSWORD = get_var('LORE_EMAIL_PASSWORD', '')
 EMAIL_USE_TLS = get_var('LORE_EMAIL_TLS', False)
+EMAIL_SUPPORT = get_var('LORE_SUPPORT_EMAIL', 'support@example.com')
 DEFAULT_FROM_EMAIL = get_var('LORE_FROM_EMAIL', 'webmaster@localhost')
 
 # e-mail configurable admins

--- a/ui/templates/welcome.html
+++ b/ui/templates/welcome.html
@@ -3,7 +3,12 @@
     <div class="section-header">
         <div class="row">
             <div class="col-md-2 col-md-offset-5">{% if perms.learningresources.add_repository %}<a href="{% url 'create_repo' %}" role="button"
-                                                     class="btn btn-primary btn-large">Create repository</a>{% endif %}</div>
+                                                     class="btn btn-primary btn-large">Create repository</a>
+                {% else %}
+                    <a href="mailto:{{ support_email }}?subject=[LORE-app]Request%20permission%20to%20create%20repositories" role="button"
+                       class="btn btn-primary btn-large">Request permission to create repositories</a>
+                {% endif %}
+            </div>
         </div>
     </div>
 

--- a/ui/tests/test_learningresources_views.py
+++ b/ui/tests/test_learningresources_views.py
@@ -55,6 +55,8 @@ class TestViews(LoreTestCase):
         body = self.assert_status_code("/", HTTP_OK, return_body=True)
         self.assertTrue("<title>MIT - LORE </title>" in body)
         self.assertTrue('>Create repository</a>' in body)
+        self.assertFalse('Request permission to create '
+                         'repositories</a>' in body)
 
     def test_get_home_norepo(self):
         """Home Page with no authorization to create repositories"""
@@ -67,6 +69,8 @@ class TestViews(LoreTestCase):
         self.assertTrue("<title>MIT - LORE </title>" in body)
         self.assertFalse('<a href="/lore/create_repo/">'
                          'Create repository</a>' in body)
+        self.assertTrue('Request permission to create '
+                        'repositories</a>' in body)
 
     def test_create_repo_post(self):
         """Create repo."""

--- a/ui/views.py
+++ b/ui/views.py
@@ -173,7 +173,10 @@ def welcome(request):
     return render(
         request,
         "welcome.html",
-        {"repos": get_repos(request.user.id)}
+        {
+            "repos": get_repos(request.user.id),
+            "support_email": settings.EMAIL_SUPPORT,
+        }
     )
 
 


### PR DESCRIPTION
Add `mailto:` link to welcome page. The link opens the user's email client
with the `to:` field filled in by the contents of `LORE_SUPPORT_EMAIL`.

Fixes: #169
[finishes #97013414]
