### PR TITLE
Rc/0.3.0

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,22 @@
 Release Notes
 -------------
 
+Version 0.3.0
+=============
+
+- Added UI to add and remove repository members.
+- Added form for adding new vocabularies.
+- Added manage taxonomies panel and button
+- REST for repo members
+- Implemented taxonomy model delete cascading.
+- Renamed "Copy to Clipboard" to "Select XML"
+- Setup JSX processing requirements.
+- Fixed mis-resolutioned learning resource type icons.
+- Converted several large HTML blocks into include files.
+- Switched from using main.js for everything to multiple modules.
+- Installed lodash.
+- Added CSRF jQuery initialization code.
+
 Version 0.2.0
 =============
 

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -15,7 +15,7 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 import yaml
 
-VERSION = '0.2.0'
+VERSION = '0.3.0'
 
 CONFIG_PATHS = [
     os.environ.get('LORE_CONFIG', ''),

--- a/ui/templates/includes/taxonomy_panel.html
+++ b/ui/templates/includes/taxonomy_panel.html
@@ -12,20 +12,14 @@
             <span class="hidden-xs">Taxonomies</span>
           </a>
         </li>
-        <!-- <li class="tab-long"> -->
-        <!--   <a href="#tab-vocab" data-toggle="tab" aria-expanded="false"> -->
-        <!--     <span class="hidden-xs">Add Vocabulary</span> -->
-        <!--   </a> -->
-        <!-- </li> -->
+        <li class="tab-long">
+          <a href="#tab-vocab" data-toggle="tab" aria-expanded="false">
+            <span class="hidden-xs">Add Vocabulary</span>
+            
+          </a>
+        </li>
       </ul>
-      <div class="tab-content drawer-tab-content">
-        <div class="tab-pane active" id="tab-taxonomies">
-        </div>
-        <div class="tab-pane drawer-tab-content" id="tab-vocab">
-          <form class="form-horizontal">
-            <p><button class="btn btn-lg btn-primary">Save</button></p>
-          </form>
-        </div>
+      <div id="taxonomy-component">
       </div>
     </div>
     <!-- cd-panel-content -->


### PR DESCRIPTION
-  [x] Added UI to add and remove repository members.
  [Giovanni Di Milia](gdimilia@mit.edu)
-  [x] Added form for adding new vocabularies.
  [Carson Gee](x@carsongee.com)
-  [x] Added manage taxonomies panel and button
  [George Schneeloch](gschneel@mit.edu)
-  [x] Added Requires.io badge
  [Brandon DeRosier](bdero@mit.edu)
-  [x] ~~Tests for members REST
  [Giovanni Di Milia](gdimilia@mit.edu)~~
-  [x] REST for repo members
  [Giovanni Di Milia](gdimilia@mit.edu)
-  [x] Implemented taxonomy model delete cascading
  [George Schneeloch](gschneel@mit.edu)
-  [x] ~~Pylint: global disable for abstract-method
  [Giovanni Di Milia](gdimilia@mit.edu)~~
-  [x] Renamed &#39;Copy to Clipboard&#39; to &#39;Select Text&#39;
  [George Schneeloch](gschneel@mit.edu)
-  [x] ~~Removed duplicate m2m field
  [George Schneeloch](gschneel@mit.edu)~~
-  [x] Setup JSX processing requirements
  [George Schneeloch](gschneel@mit.edu)
-  [x] Fixed mis-resolutioned learning resource type icons
  [Carson Gee](x@carsongee.com)
-  [x] ~~Switched from using main.js for everything to multiple modules
  [Carson Gee](x@carsongee.com)~~
-  [x] ~~Install lodash
  [George Schneeloch](gschneel@mit.edu)~~
-  [x] Added CSRF jQuery initialization code
  [George Schneeloch](gschneel@mit.edu)
