### PR TITLE
Remove unused patterns to limit memory use

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,14 +40,6 @@ module.exports = function(config) {
       {
         pattern:'ui/jstests/**/*.jsx',
         included: false
-      },
-      {
-        pattern: 'node_modules/**/*.js',
-        included: false
-      },
-      {
-        pattern: 'node_modules/**/*.jsx',
-        included: false
       }
     ],
 


### PR DESCRIPTION
My laptop has 8GB memory but others with less memory on their Docker containers ran out of memory due to the large amount of imported javascript. On further investigation importing `node_modules` isn't actually necessary so it's removed
