### PR TITLE
Fixed `KeyError` on repository page if search index is reset.

### DIFF
--- a/ui/views.py
+++ b/ui/views.py
@@ -245,16 +245,17 @@ class RepositoryView(FacetedSearchView):
                 )
             qs_prefix = "?{0}&".format("&".join(qs_prefix))
 
-        context.update({
-            "repo": self.repo,
-            "perms_on_cur_repo": get_perms(self.request.user, self.repo),
-            "vocabularies": {
-                k: v
-                for k, v in context["facets"]["fields"].items()
-                if k in vocabularies
-            },
-            "qs_prefix": qs_prefix,
-        })
+        if "fields" in context["facets"]:
+            context.update({
+                "repo": self.repo,
+                "perms_on_cur_repo": get_perms(self.request.user, self.repo),
+                "vocabularies": {
+                    k: v
+                    for k, v in context["facets"]["fields"].items()
+                    if k in vocabularies
+                },
+                "qs_prefix": qs_prefix,
+            })
         return context
 
     def build_form(self, form_kwargs=None):


### PR DESCRIPTION
This wouldn't happen in production, but it can happen (for a brief window)
running the application in Docker containers.

Closes #283.

Note about tests:
The system behaves differently during testing than when running. When testing,
a test for this passes without the fix. When Django is running normally,
it will return the `KeyError` after a forced index wipe, but only until
Django is restarted. Then it works normally.

Digging into exactly what changes in Haystack (or Elasticsearch) when Django is restarted (some kind of caching?) is too
time-consuming for the repayment in test coverage. As a result, this branch causes a minor
hit in test coverage.
