### PR TITLE
Fixed error message on unsupported terms in learning resource

### DIFF
--- a/rest/serializers.py
+++ b/rest/serializers.py
@@ -192,7 +192,8 @@ class LearningResourceSerializer(ModelSerializer):
             if not term.vocabulary.learning_resource_types.filter(
                     name=resource_type.name).exists():
                 raise ValidationError(
-                    "Term {} is not supported for this learning resource")
+                    "Term {} is not supported "
+                    "for this learning resource".format(term.label))
         return terms
 
 


### PR DESCRIPTION
Looks like I missed an argument during `format()`
