### PR TITLE
Allowed blank descriptions for LearningResource model

### DIFF
--- a/learningresources/migrations/0009_allow_blank_description.py
+++ b/learningresources/migrations/0009_allow_blank_description.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+# pylint: skip-file
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0008_remove_staticasset_learning_resources'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='learningresource',
+            name='description',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/learningresources/models.py
+++ b/learningresources/models.py
@@ -95,7 +95,7 @@ class LearningResource(BaseModel):
     static_assets = models.ManyToManyField(StaticAsset, blank=True)
     uuid = models.TextField()
     title = models.TextField()
-    description = models.TextField()
+    description = models.TextField(blank=True)
     content_xml = models.TextField()
     materialized_path = models.TextField()
     url_path = models.TextField()


### PR DESCRIPTION
Since we populate blank `LearningResource` descriptions during import it makes sense that we allow users to leave descriptions blank too
