### PR TITLE
Fixed bug with file path length in static assets

### DIFF
--- a/learningresources/migrations/0010_static_asset_file_length.py
+++ b/learningresources/migrations/0010_static_asset_file_length.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import learningresources.models
+
+# pylint: skip-file
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0009_allow_blank_description'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='staticasset',
+            name='asset',
+            field=models.FileField(
+                max_length=900,
+                upload_to=learningresources.models.static_asset_basepath
+            ),
+        ),
+    ]

--- a/learningresources/tests/test_models.py
+++ b/learningresources/tests/test_models.py
@@ -3,18 +3,79 @@ Tests for learningresources models
 """
 from __future__ import unicode_literals
 
+import os
+import random
+import string
+from shutil import rmtree
+from tempfile import mkdtemp
+
+from django.core.files import File
 from mock import MagicMock
 
 from .base import LoreTestCase
 from learningresources.models import (
+    FILE_PATH_MAX_LENGTH,
     LearningResourceType,
     Repository,
-    static_asset_basepath
+    static_asset_basepath,
+    StaticAsset,
+    FilePathLengthException
 )
+
+
+def get_random_string(length):
+    """Helper function to generate strings with random characters"""
+    return ''.join(
+        random.SystemRandom(0).choice(
+            string.ascii_letters + string.digits
+        ) for _ in range(length)
+    )
+
+
+def get_random_path(length):
+    """Helper function to generate strings with random characters"""
+    if length < 256:
+        return get_random_string(length)
+    file_path = ''
+    while len(file_path) < length:
+        if length - len(file_path) > 255:
+            file_path += get_random_string(255)
+            file_path += os.sep
+        else:
+            file_path += get_random_string(length - len(file_path))
+    return file_path
+
+
+def create_dumb_file(temp_dir_path, basename_length):
+    """helper function to create test files"""
+    random_path = get_random_path(basename_length)
+    # saving current directory
+    cur_dir = os.getcwd()
+    # going to the base of the directory that should be already there
+    os.chdir(temp_dir_path)
+    # create the chain of folders
+    splitted_path = random_path.split(os.sep)
+    while len(splitted_path) > 1:
+        dirname = splitted_path.pop(0)
+        os.mkdir(dirname)
+        os.chdir(dirname)
+    # finally create the file
+    file_contents = 'hello\n'
+    with open(splitted_path[0], 'w') as temp:
+        temp.write(file_contents)
+    os.chdir(cur_dir)
+    return os.path.join(temp_dir_path, random_path)
+
+
+class MockAsset(object):
+    """Mock Asset class"""
+    def __init__(self, course):
+        self.course = course
 
 
 class TestModels(LoreTestCase):
     """Tests for learningresources models"""
+    # pylint: disable=invalid-name
 
     def test_unicode(self):
         """Test for __unicode__ on LearningResourceType"""
@@ -57,3 +118,48 @@ class TestModels(LoreTestCase):
             path,
             'assets/hi/1/runnow/asdf/asdf.txt'
         )
+
+    def test_static_asset_filename_length(self):
+        """
+        Tests that user can use django FileField long up to
+        FILE_PATH_MAX_LENGTH characters
+        """
+        temp_dir_path = mkdtemp()
+        self.addCleanup(rmtree, temp_dir_path)
+
+        # test with small file name
+        file_path = create_dumb_file(temp_dir_path, 10)
+        with open(file_path) as file_handle:
+            StaticAsset.objects.create(
+                course=self.course,
+                asset=File(file_handle)
+            )
+        # test with file name of exactly the max length
+        base_path = static_asset_basepath(MockAsset(self.course), '')
+        file_path = create_dumb_file(
+            temp_dir_path,
+            (
+                # max file size
+                FILE_PATH_MAX_LENGTH -
+                # minus the length of the base path of the Django storage and
+                # the base path of the file location temporary dir
+                len(os.path.join(base_path, temp_dir_path)) -
+                # minus 1 for the extra "/" to joint the paths
+                1
+            )
+        )
+        with open(file_path) as file_handle:
+            StaticAsset.objects.create(
+                course=self.course,
+                asset=File(file_handle)
+            )
+        # test with file name of more the max length
+        file_path = create_dumb_file(temp_dir_path, FILE_PATH_MAX_LENGTH+1)
+        with open(file_path) as file_handle:
+            self.assertRaises(
+                FilePathLengthException,
+                lambda: StaticAsset.objects.create(
+                    course=self.course,
+                    asset=File(file_handle)
+                )
+            )


### PR DESCRIPTION
It looked like a tiny bug but instead I ended up facing some nasty behaviors.
In particular, writing tests, I discovered that on postgres the `max_length` of the `models.FileField` is not enforced and instead the file paths get truncated.
I wrote a better description of the issue on Stackoverflow:
http://stackoverflow.com/questions/31325164/django-filefield-custom-max-length-seems-not-to-be-enforced

Fixes #315
