### PR TITLE
Added terms to the readonly list

### DIFF
--- a/rest/serializers.py
+++ b/rest/serializers.py
@@ -180,7 +180,7 @@ class LearningResourceSerializer(ModelSerializer):
             'xa_histogram_grade',
             'terms',
         )
-        read_only_fields = tuple(set(fields) - {'description'})
+        read_only_fields = tuple(set(fields) - {'description', 'terms'})
 
     def validate_terms(self, terms):
         """


### PR DESCRIPTION
`learning_resources` terms are editable but because it's a related field its presence in `read_only_fields` is ignored. This shouldn't change any functionality but the change would prevent some confusion
