### PR TITLE
Set QUnit timeout to fix test error reporting

### DIFF
--- a/ui/jstests/test-utils.jsx
+++ b/ui/jstests/test-utils.jsx
@@ -1,6 +1,8 @@
-define("test_utils", ["jquery", "stacktrace", "lodash",
-  "jquery_mockjax"], function($, printStackTrace, _) {
+define("test_utils", ["jquery", "stacktrace", "lodash", "QUnit",
+  "jquery_mockjax"], function($, printStackTrace, _, QUnit) {
   'use strict';
+
+  QUnit.config.testTimeout = 5000;
 
   /**
    * Number of AJAX calls intercepted by mockjax


### PR DESCRIPTION
Karma times out after 10 seconds, this sets QUnit's per-test timeout to 5 seconds. When Karma times out it doesn't provide any useful information about where things went wrong. Since all tests are importing TestUtils we can set a smaller timeout for QUnit so that it will definitely fail the test before Karma's timeout can occur. This makes it so that all our tests provide pass or fail results in the test output.
