### PR TITLE
Removed unused piece of state

### DIFF
--- a/ui/static/ui/js/manage_taxonomies.jsx
+++ b/ui/static/ui/js/manage_taxonomies.jsx
@@ -83,8 +83,7 @@ define('setup_manage_taxonomies', ['reactaddons', 'lodash', 'jquery', 'utils'],
     },
     getInitialState: function() {
       return {
-        newTermLabel: "",
-        terms: this.props.terms
+        newTermLabel: ""
       };
     },
   });


### PR DESCRIPTION
`terms` was moved to `this.props` but I missed this instance of `terms` on the state. It is not used anywhere so removing shouldn't cause a problem.
