### PR TITLE
Reported code coverage for javascript on the command line

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -89,6 +89,11 @@ module.exports = function(config) {
           type: 'lcovonly',
           subdir: '.',
           file: 'coverage-js.lcov'
+        },
+        {
+          type: 'text-summary',
+          subdir: '.',
+          file: 'text-summary.txt'
         }
       ]
     },

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,11 @@ commands =
     {toxinidir}/node_modules/.bin/jscs ui/static/ui/js ui/jstests/
     {toxinidir}/node_modules/.bin/karma start {posargs}
     {toxinidir}/util/convert_lcov_to_coveralls.js {toxinidir}/coverage/coverage-js.lcov {toxinidir}/coverage/coverage-js.json
+    cat {toxinidir}/coverage/text-summary.txt
 
 whitelist_externals =
     */karma
     npm
     js
+    cat
 deps = 


### PR DESCRIPTION
After running `tox -e js` you should see code coverage summary information (in color!)
