### PR TITLE
Added bootstrap style to vocabularly learning type checkboxes

### DIFF
--- a/ui/static/ui/js/manage_taxonomies.jsx
+++ b/ui/static/ui/js/manage_taxonomies.jsx
@@ -221,12 +221,20 @@ define('setup_manage_taxonomies', ['reactaddons', 'lodash', 'jquery', 'utils'],
 
       var checkboxes = _.map(this.props.learningResourceTypes, function(type) {
         var checked = _.includes(thiz.state.learningResourceTypes, type);
-        return <li key={type}><label><input type="checkbox"
-                      value={type}
-                      checked={checked}
-                      onChange={thiz.updateLearningResourceType} />
-          {type}
-        </label></li>;
+        return (
+            <li key={type}>
+              <div className="checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    value={type}
+                    checked={checked}
+                    onChange={thiz.updateLearningResourceType} />
+                  {type}
+                </label>
+              </div>
+            </li>
+        );
       });
 
       return (
@@ -243,7 +251,7 @@ define('setup_manage_taxonomies', ['reactaddons', 'lodash', 'jquery', 'utils'],
             placeholder="Description"/>
           </p>
           <p>
-            <ul>
+            <ul className="icheck-list">
             {checkboxes}
             </ul>
           </p>


### PR DESCRIPTION
After spending an hour in a losing battle to get iCheck to work with React (they appear to be completely incompatible), I went with just the simple bootstrap check syling.
## Before:

![image](https://cloud.githubusercontent.com/assets/596029/8736421/37fe4982-2be6-11e5-8217-c8ef5bf7842b.png)
## After

![image](https://cloud.githubusercontent.com/assets/596029/8736423/47a07338-2be6-11e5-9fec-fbab7109c77e.png)
