### PR TITLE
Fixed comparison of FileFields to strings.

### DIFF
--- a/importer/tests/test_import.py
+++ b/importer/tests/test_import.py
@@ -286,9 +286,10 @@ class TestImportToy(LoreTestCase):
         ).distinct()
         self.assertEqual(htmls.count(), 1)
         self.assertEqual(
-            [asset.asset for asset in htmls[0].static_assets.all()],
-            [
+            sorted([
+                asset.asset.name for asset in htmls[0].static_assets.all()]),
+            sorted([
                 "assets/edX/toy/TT_2012_Fall/essays_x250.png",
                 "assets/edX/toy/TT_2012_Fall/webGLDemo.css",
-            ]
+            ])
         )


### PR DESCRIPTION
fixes #376

Also explicitly sorts instead of depending on chance.
