### PR TITLE
Implemented learning resource panel updating on every panel open

### DIFF
--- a/ui/static/ui/js/learning_resources.jsx
+++ b/ui/static/ui/js/learning_resources.jsx
@@ -222,9 +222,11 @@ define('learning_resources', [
     VocabularyOption: VocabularyOption,
     LearningResourcePanel: LearningResourcePanel,
     loader: function (repoSlug, learningResourceId, container) {
+      // Unmount and remount the component to ensure that its state
+      // is always up to date with the rest of the app.
+      React.unmountComponentAtNode(container);
       React.render(<LearningResourcePanel
         repoSlug={repoSlug} learningResourceId={learningResourceId}
-        key={[repoSlug, learningResourceId]}
         />, container);
     }
   };


### PR DESCRIPTION
Fixes #338 

This causes the panel to always update which means existing text or errors will be forgotten if the user closes the panel.
