### PR TITLE
Fixed display of vocabulary terms containing spaces.

### DIFF
--- a/importer/tests/test_import.py
+++ b/importer/tests/test_import.py
@@ -286,9 +286,10 @@ class TestImportToy(LoreTestCase):
         ).distinct()
         self.assertEqual(htmls.count(), 1)
         self.assertEqual(
-            [asset.asset for asset in htmls[0].static_assets.all()],
-            [
+            sorted([
+                asset.asset.name for asset in htmls[0].static_assets.all()]),
+            sorted([
                 "assets/edX/toy/TT_2012_Fall/essays_x250.png",
                 "assets/edX/toy/TT_2012_Fall/webGLDemo.css",
-            ]
+            ])
         )

--- a/search/search_indexes.py
+++ b/search/search_indexes.py
@@ -87,9 +87,12 @@ class LearningResourceIndex(indexes.SearchIndex, indexes.Indexable):
         """
         prepared = super(LearningResourceIndex, self).prepare(obj)
         for vocab in Vocabulary.objects.all():
-            # Values with spaces do not work, so we use the slug.
+            # Values with spaces do not work, so replace them with underscores.
+            # Slugify doesn't work because it adds hypens, which are also
+            # split by Elasticsearch.
             terms = [
-                term.label for term in obj.terms.filter(vocabulary_id=vocab.id)
+                term.label.replace(" ", "_")
+                for term in obj.terms.filter(vocabulary_id=vocab.id)
             ]
             prepared[vocab.slug] = terms
             # for faceted "_exact" in URL

--- a/search/tests/base.py
+++ b/search/tests/base.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests for search engine indexing."""
 
 from learningresources.tests.base import LoreTestCase
@@ -20,7 +21,7 @@ class SearchTestCase(LoreTestCase):
             Term.objects.create(
                 vocabulary_id=self.vocabulary.id, label=label, weight=1
             )
-            for label in ("easy", "medium", "difficult")
+            for label in ("easy", "medium", "very difficult", "ancòra")
         ]
 
     def count_results(self, query):

--- a/search/tests/test_search_view.py
+++ b/search/tests/test_search_view.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests for repostitory listing view search."""
 
 from django.core.urlresolvers import reverse
@@ -28,3 +29,14 @@ class TestSearchView(SearchTestCase):
         )
         resp = self.client.get(reverse("repositories", args=(new_repo.slug,)))
         self.assertNotContains(resp, self.resource.title)
+
+    def test_terms_with_spaces(self):
+        """
+        Terms with spaces should show up in facet list correctly.
+        """
+        for term in self.terms:
+            self.resource.terms.add(term)
+        resp = self.client.get(reverse("repositories", args=(self.repo.slug,)))
+        self.assertContains(resp, "easy")
+        self.assertContains(resp, "ancòra")
+        self.assertContains(resp, "very difficult")

--- a/ui/templates/includes/facet_panel.html
+++ b/ui/templates/includes/facet_panel.html
@@ -128,7 +128,7 @@
                  data-facet-name="{{ name|urlencode }}_exact"
                  data-facet-value="{{ term.0 }}"
           >
-          <label for="check-{{ name }}-{{ forloop.counter }}">{{ term.0 }}</label>
+          <label for="check-{{ name }}-{{ forloop.counter }}">{{ term.2 }}</label>
           <span class="badge">{{ term.1 }}</span>
         </li>
         {% endfor %}

--- a/ui/views.py
+++ b/ui/views.py
@@ -167,8 +167,10 @@ class RepositoryView(FacetedSearchView):
             context.update({
                 "repo": self.repo,
                 "perms_on_cur_repo": get_perms(self.request.user, self.repo),
+                # Add a non-slug version to the context for display. This
+                # turns a "two-tuple" into a "three-tuple."
                 "vocabularies": {
-                    k: v
+                    k: [x + (x[0].replace("_", " "),) for x in v]
                     for k, v in context["facets"]["fields"].items()
                     if k in vocabularies
                 },


### PR DESCRIPTION
```
Fixed display of vocabulary terms containing spaces.

fixes #367

I spent some (too much) time on the command line using the elasticsearch
module trying to figure out how to fix the search to work with spaces.

In the end, I went for the obvious, lame solution. Eventually it seems
like we'll want to ditch Haystack and use Elasticsearch directly.
```
