### PR TITLE
Release 0.5.0

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,24 @@
 Release Notes
 -------------
 
+Version 0.5.0
+=============
+
+- Fixed display of vocabulary terms containing spaces.
+- Fixed comparison of FileFields to strings.
+- Fixed typo in search hint
+- Added bootstrap style to vocabularly learning type checkboxes Closes #337
+- Changed search box description
+- Fixed mutating of this.state which is forbidden
+- Added static file parsing to HTML elements.
+- Removed vocabulary forms since we are doing this via REST API and React instead
+- Reported code coverage for javascript on the command line
+- Added function to obtain collections
+- Set QUnit timeout to fix test error reporting
+- Added HTML reporting of javascript tests
+- Added panel for static assets
+- Added link to request create repository permission
+
 Version 0.4.0
 =============
 

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -15,7 +15,7 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 import yaml
 
-VERSION = '0.4.0'
+VERSION = '0.5.0'
 
 CONFIG_PATHS = [
     os.environ.get('LORE_CONFIG', ''),

--- a/util/release_notes_rst.ejs
+++ b/util/release_notes_rst.ejs
@@ -1,4 +1,4 @@
-Version 0.4.0
+Version 0.5.0
 =============
 
 <% commits.forEach(function (commit) { %>- <%= commit.title %>


### PR DESCRIPTION
Release 0.5.0
- Fixed display of vocabulary terms containing spaces.
- Fixed comparison of FileFields to strings.
- Fixed typo in search hint.
- Added bootstrap style to vocabulary learning type checkboxes.
- Changed search box description.
- Fixed mutating of this.state which is forbidden.
- Added static file parsing to HTML elements.
- Removed vocabulary forms since we are doing this via REST API and React instead.
- Reported code coverage for Javascript on the command line.
- Added function to obtain collections.
- Set QUnit timeout to fix test error reporting.
- Added HTML reporting of Javascript tests.
- Added panel for static assets.
- Added link to request create repository permission
