### PR TITLE
Used different haystack index for tests to prevent conflict with web application

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands = py.test {posargs}
 passenv = *
 setenv =
     CELERY_ALWAYS_EAGER=True
+    HAYSTACK_INDEX=testindex
     LORE_DB_DISABLE_SSL=True
 
 [testenv:docs]


### PR DESCRIPTION
The environment variable tells haystack to use a different name for its index
