### PR TITLE
Fixed preview link not showing up in list view

### DIFF
--- a/ui/templates/includes/learning_resource.html
+++ b/ui/templates/includes/learning_resource.html
@@ -45,7 +45,7 @@
         <div class="tile-meta">
           <span class="meta-item">{{ result.object.course.course_number }}</span>
           <span class="meta-item">{{ result.object.course.run }}</span>
-          <span class="meta-item"><a href="{{ result.object.preview_url }}" target="_blank">Preview</a></span>
+          <span class="meta-item"><a href="{{ result.object.get_preview_url }}" target="_blank">Preview</a></span>
         </div>
       </div>
     </div>

--- a/ui/tests/test_learningresources_views.py
+++ b/ui/tests/test_learningresources_views.py
@@ -28,6 +28,7 @@ NOT_FOUND = 404
 log = logging.getLogger(__name__)
 
 
+# pylint: disable=too-many-public-methods
 class TestViews(LoreTestCase):
     """Hit each view."""
 
@@ -376,3 +377,12 @@ class TestViews(LoreTestCase):
             # this is in case of python 3.3
             except AttributeError:  # pragma: no cover
                 imp.reload(ui.urls)
+
+    def test_preview_url(self):
+        """Test that preview url shows up correctly"""
+        resp = self.client.get(self.repository_url, follow=True)
+        self.assertIn(
+            '<a href="https://www.sandbox.edx.org/courses/test-org/'
+            'infinity/Febtober/jump_to_id/url_name1" '
+            'target="_blank">Preview</a>',
+            resp.content.decode('utf-8'))


### PR DESCRIPTION
When `preview_url` was changed from a property to a method I forgot to update the template accordingly. There's also a test to verify this
