### PR TITLE
Updated Haystack to 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,4 @@ deploy:
   run:
     - "sleep 15"
     - "python manage.py migrate --noinput"
-    - "python manage.py update_index"
     - "python manage.py sync_permissions"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django==1.8.3
 django-appconf==1.0.1
 django-bootstrap3==6.1.0
 django-compressor==1.5
-django-haystack==2.3.1
+django-haystack==2.4.0
 djangorestframework==3.1.3
 dj-database-url==0.3.0
 dj-static==0.0.6


### PR DESCRIPTION
- Removed automatic index update from deployment

The deprecated class views we are using were not removed, so is working fine with 2.4.0.  Also, after having learned from @giocalitri and @ShawnMilo that ES isn't used in the listing page it occurred to me that the only time we would ever need to rebuild the index is if we added a new facet type, or changed what is searchable in the text field.  Since those will likely be very rare events, I think we can remove the index update from the build process and just do them manually as needed since I don't see this happening much at all.  I am definitely open for counter suggestions.
