### PR TITLE
Changed response vocabulary name to match input and avoid key collision

### DIFF
--- a/ui/jstests/test_manage_taxonomies.jsx
+++ b/ui/jstests/test_manage_taxonomies.jsx
@@ -892,6 +892,20 @@ define(['QUnit', 'jquery', 'setup_manage_taxonomies', 'reactaddons',
             checkboxCourse,
             {target: {value: 'course', checked: true}}
           );
+          TestUtils.replaceMockjax({
+            url: "/api/v1/repositories/repo/vocabularies/",
+            type: "POST",
+            responseText: {
+              "id": 2,
+              "slug": "test-a",
+              "name": "TestA",
+              "description": "TestA",
+              "vocabulary_type": "m",
+              "required": false,
+              "weight": 1,
+              "terms": []
+            }
+          });
           React.addons.TestUtils.Simulate.submit(formNode);
           waitForAjax(1, function() {
             assert.equal(


### PR DESCRIPTION
Fixes #409 

This changes the mocked response to update the key created by react, avoiding a key collision.
