### PR TITLE
Avoided hitting the database for the search page.

### DIFF
--- a/search/search_indexes.py
+++ b/search/search_indexes.py
@@ -42,6 +42,15 @@ class LearningResourceIndex(indexes.SearchIndex, indexes.Indexable):
     nr_attempts = indexes.IntegerField(model_attr="xa_nr_attempts")
     avg_grade = indexes.FloatField(model_attr="xa_avg_grade")
 
+    lid = indexes.IntegerField(model_attr="id", indexed=False)
+    title = indexes.CharField(model_attr="title", indexed=False)
+    description = indexes.CharField(model_attr="description", indexed=False)
+    description_path = indexes.CharField(
+        model_attr="description_path",
+        indexed=False,
+    )
+    preview_url = indexes.CharField(indexed=False)
+
     def get_model(self):
         """Return the model for which this configures indexing."""
         return LearningResource
@@ -72,6 +81,10 @@ class LearningResourceIndex(indexes.SearchIndex, indexes.Indexable):
     def prepare_run(self, obj):  # pylint: disable=no-self-use
         """Define what goes into the "run" index."""
         return obj.course.run
+
+    def prepare_preview_url(self, obj):  # pylint: disable=no-self-use
+        """Define what goes into the "run" index."""
+        return obj.get_preview_url()
 
     @staticmethod
     def prepare_course(obj):

--- a/search/tests/test_search_view.py
+++ b/search/tests/test_search_view.py
@@ -2,12 +2,16 @@
 """Tests for repostitory listing view search."""
 from __future__ import unicode_literals
 
+import logging
+
 from django.core.urlresolvers import reverse
 
 from learningresources.api import create_repo
 from roles.api import assign_user_to_repo_group
 from roles.permissions import GroupTypes
 from search.tests.base import SearchTestCase
+
+log = logging.getLogger(__name__)
 
 
 class TestSearchView(SearchTestCase):
@@ -41,3 +45,14 @@ class TestSearchView(SearchTestCase):
         self.assertContains(resp, "easy")
         self.assertContains(resp, "ancòra")
         self.assertContains(resp, "very difficult")
+
+    def test_db_hits(self):
+        """
+        Search should not load LearningResources from the database.
+        """
+        with self.assertNumQueries(10):
+            resp = self.client.get(
+                reverse("repositories", args=(self.repo.slug,)))
+
+        # We shouldn't have hit the db to get this.
+        self.assertContains(resp, self.resource.title)

--- a/ui/templates/includes/learning_resource.html
+++ b/ui/templates/includes/learning_resource.html
@@ -26,36 +26,36 @@
       </div>
       <div class="tile-content">
         <h2>
-          <a href="#" class="cd-btn" data-learningresource-id="{{ result.object.id }}">
-            {% if result.object.title %}
-            {{ result.object.title }}
+          <a href="#" class="cd-btn" data-learningresource-id="{{ result.lid }}">
+            {% if result.title %}
+            {{ result.title }}
             {% else %}
             No Title
             {% endif %}
           </a>
         </h2>
-        
+
         <div class="tile-meta">
-          <span class="meta-item">{{ result.object.description_path }}</span>
+          <span class="meta-item">{{ result.description_path }}</span>
         </div>
         <div class="tile-blurb">
-          {% if result.object.description %}
-          {{ result.object.description }}
+          {% if result.description %}
+          {{ result.description }}
           {% else %}
           No description provided.
           {% endif %}
         </div>
         <div class="tile-meta">
-          <span class="meta-item">{{ result.object.course.course_number }}</span>
-          <span class="meta-item">{{ result.object.course.run }}</span>
-          <span class="meta-item"><a href="{{ result.object.get_preview_url }}" target="_blank">Preview</a></span>
+          <span class="meta-item">{{ result.course }}</span>
+          <span class="meta-item">{{ result.run }}</span>
+          <span class="meta-item"><a href="{{ result.preview_url }}" target="_blank">Preview</a></span>
         </div>
       </div>
     </div>
   </div>
   <div class="col-md-2 col-export">
-    <a class="link-export" href="#" data-learningresource-id="{{ result.object.id }}"
-       {% if result.object.id in exports %}
+    <a class="link-export" href="#" data-learningresource-id="{{ result.lid }}"
+       {% if result.lid in exports %}
          data-selected="true"
        {% else %}
          data-selected="false"

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -42,6 +42,7 @@ urlpatterns = [
         login_required(
             RepositoryView(
                 form_class=SearchForm, template="repository.html",
+                load_all=False,
             )
         ),
         name='repositories'


### PR DESCRIPTION
Load data elements from LearningResources into the Elasticsearch index,
so they can be inserted into the template from the query results, not
requiring a DB lookup.

Also added a test which should catch regressions. There are still queries
due to the checks to authentication and session management, but there
are no queries to learningresources_learningresource.

Closes #402.

Used documentation from [Haystack](https://django-haystack.readthedocs.org/en/v2.4.0/best_practices.html#avoid-hitting-the-database) and [a blog](https://www.dominicrodger.com/order-n-haystack.html) as suggested in #402. In testing, the `load_all` argument to the view didn't make a difference as suggested in the Haystack documentation, but I left it in there anyway just in case it helps an edge case.
