### PR TITLE
Fix test failures due to pylint dependency chain

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,10 @@
 
 pytest
 pytest-pep8
+# logilab-common is only necessary because pylint's dependency chain will
+# result in the latest logilab-common being fetched, but astroid
+# (another pylint dependency) depends on logilab-common<=0.63.0
+logilab-common==0.63.0
 pytest-pylint
 pytest-cov
 pytest-django


### PR DESCRIPTION
logilab-common is only necessary because pylint's dependency chain
will result in the latest logilab-common being fetched, but astroid
(another pylint dependency) depends on logilab-common<=0.63.0
