### PR TITLE
Changed vocabularies listing page to match the design

### DIFF
--- a/ui/jstests/test_manage_taxonomies.jsx
+++ b/ui/jstests/test_manage_taxonomies.jsx
@@ -63,7 +63,7 @@ define(['QUnit', 'jquery', 'setup_manage_taxonomies', 'reactaddons',
         devItems,
         'li'
     );
-    assert.equal(itemList.length, 2);
+    assert.equal(itemList.length, 3);
     return devItems;
   }
   QUnit.module('Test taxonomies panel', {
@@ -251,7 +251,7 @@ define(['QUnit', 'jquery', 'setup_manage_taxonomies', 'reactaddons',
             devItems,
             'li'
         );
-        assert.equal(itemList.length, 2);
+        assert.equal(itemList.length, 3);
         //test enter text in input text
         var inputNode = React.addons.TestUtils.
           findRenderedDOMComponentWithTag(

--- a/ui/static/ui/css/mit-lore.css
+++ b/ui/static/ui/css/mit-lore.css
@@ -124,19 +124,30 @@ a {
 }
 
 .panel-heading .accordion-toggle:before {
-    font-family: 'FontAwesome'; 
-    content: "\f078";        
+    font-family: 'FontAwesome';
+    content: "\f078";
     color: #F5A623;
     font-size: 12px;
-    margin:-3px 0 0 0;
+    margin:0;
     line-height: 1em;
     width:16px;
-    display: inline-block; 
-    text-align: center;    
+    font-weight:400 !important;
+    display: inline-block;
+    text-align: center;
+    position:relative;
+    top:-2px;
 }
 
 .panel-heading .accordion-toggle.collapsed:before {
-    content: "\f054";   
+    content: "\f054";
+}
+
+.lore-panel-group.panel-body {
+	padding:8px 0 0 36px;
+}
+
+.panel-title {
+    font-weight: 700;
 }
 
 .lore-panel-group.panel-body {
@@ -161,13 +172,13 @@ a {
 
 .icheck-list {
 	list-style: none;
-	margin:0 0 0 0;
+	margin:0 0 0 16px;
 	padding:0;
 }
 
 .icheck-list li {
 	margin:0 0 10px 0;
-}	
+}
 
 .icheck-list li span.min-width {
 	min-width: 38px;

--- a/ui/static/ui/js/manage_taxonomies.jsx
+++ b/ui/static/ui/js/manage_taxonomies.jsx
@@ -18,7 +18,7 @@ define('setup_manage_taxonomies', ['reactaddons', 'lodash', 'jquery', 'utils'],
         return <TermComponent term={term} key={term.slug} />;
       });
 
-      return <ul className="icheck-list">
+      return <div className="panel panel-default">
           <div className="panel-heading">
             <h4 className="panel-title">
               <a className="accordion-toggle" data-toggle="collapse"
@@ -31,26 +31,27 @@ define('setup_manage_taxonomies', ['reactaddons', 'lodash', 'jquery', 'utils'],
           <div id={'collapse-' + this.props.vocabulary.slug}
                className="panel-collapse collapse in">
             <div className="panel-body">
-              <ul>
+              <ul className="icheck-list">
                 {items}
+                <li>
+                  <div className="input-group">
+                    <input type="text"
+                           valueLink={this.linkState('newTermLabel')}
+                      className="form-control" onKeyUp={this.onKeyUp}
+                      placeholder="Add new term..."
+                      />
+                      <span className="input-group-btn">
+                        <a className="btn btn-white"
+                          type="button" onClick={this.handleAddTermClick}><i
+                          className="fa fa-plus-circle"
+                        ></i></a>
+                      </span>
+                  </div>
+                </li>
               </ul>
             </div>
           </div>
-        <li>
-          <div className="input-group">
-            <input type="text" valueLink={this.linkState('newTermLabel')}
-              className="form-control" onKeyUp={this.onKeyUp}
-              placeholder="Add new term..."
-              />
-              <span className="input-group-btn">
-                <a className="btn btn-white"
-                  type="button" onClick={this.handleAddTermClick}><i
-                  className="fa fa-plus-circle"
-                ></i></a>
-              </span>
-          </div>
-        </li>
-      </ul>;
+      </div>;
     },
     onKeyUp: function(e) {
       if (e.key === "Enter") {


### PR DESCRIPTION
Before
![before](https://cloud.githubusercontent.com/assets/125561/8916624/db513832-347a-11e5-8dee-6adaf6ee541f.png)

after
![after](https://cloud.githubusercontent.com/assets/125561/8916626/df7a8c38-347a-11e5-90c4-19e0d303c596.png)
