### PR TITLE
Pinned all versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ djangorestframework==3.1.3
 dj-database-url==0.3.0
 dj-static==0.0.6
 elasticsearch==1.6.0
-git+https://github.com/bpeschier/django-compressor-requirejs@889d5edc4f2acaa961c170084f1171c700649519#egg=githubdjango-compressor-requirejs-develop
+git+https://github.com/bpeschier/django-compressor-requirejs@889d5edc4f2acaa961c170084f1171c700649519#egg=githubdjango-compressor-requirejs-develop==0.4.1-odl
 psycopg2==2.6.1
 PyYAML==3.11
 redis==2.10.3
@@ -19,14 +19,14 @@ uwsgi==2.0.11
 six==1.9.0
 
 # django guardian branch that fixed bug in master
-git+https://github.com/mitodl/django-guardian@de7ca5c39dfd0870067497f5843581e9cd2b017f#egg=django-guardian-dev
+git+https://github.com/mitodl/django-guardian@de7ca5c39dfd0870067497f5843581e9cd2b017f#egg=django-guardian-dev==1.3.1-odl
 
 # cas application requirements
-git+https://github.com/mingchen/django-cas-ng@69463fe7c23f025be7165c2967f4ceb983d60472#egg=django-cas-ng
+git+https://github.com/mingchen/django-cas-ng@69463fe7c23f025be7165c2967f4ceb983d60472#egg=django-cas-ng==3.4.3-odl
 
 # Importer application requirements
 xbundle==0.3.0
-git+https://github.com/gdub/python-archive.git@61b9afde21621a8acce964d3336a7fb5d2d07ca6#egg=python-archive
+git+https://github.com/gdub/python-archive.git@61b9afde21621a8acce964d3336a7fb5d2d07ca6#egg=python-archive==0.3.1-odl
 django-storages-redux==1.2.3
 python-magic==0.4.6
 boto>=2.38.0,<3.0.0


### PR DESCRIPTION
Follow up fix to the xbundle requirement issue.  From now on we need to pin all requirements, even if we make up a version for the github ones to allow for pip to correctly upgrade them.
