### PR TITLE
Made XML preview box for a LearningResource should be read only

### DIFF
--- a/ui/static/ui/js/learning_resources.jsx
+++ b/ui/static/ui/js/learning_resources.jsx
@@ -70,6 +70,7 @@ define('learning_resources', [
         <form className="form-horizontal">
           <StatusBox message={this.state.message} />
           <textarea className="form-control textarea-xml"
+                    readOnly="true"
                     valueLink={this.linkState('contentXml')}
             />
 


### PR DESCRIPTION
Hi
In this PR I made XML preview box for a LearningResource should be read only

issue https://github.com/mitodl/lore/issues/429
@pdpinch @carsongee @giocalitri

![screen shot 2015-07-30 at 3 03 09 pm](https://cloud.githubusercontent.com/assets/10431250/8980710/22ebc72c-36cc-11e5-93aa-e6953d56f00e.png)
