### PR TITLE
Added test for StaticAsset.loader

### DIFF
--- a/ui/jstests/test-static-assets.jsx
+++ b/ui/jstests/test-static-assets.jsx
@@ -110,5 +110,14 @@ define(['QUnit', 'jquery', 'static_assets', 'reactaddons',
           ref={afterMount} />);
       }
     );
+
+    QUnit.test(
+      'Assert that loader mounts a React component', function(assert) {
+        var container = document.createElement("div");
+        assert.equal($(container).find("ul").length, 0);
+        StaticAssets.loader("repo", 1, container);
+        assert.equal($(container).find("ul").length, 1);
+      }
+    );
   }
 );


### PR DESCRIPTION
This kind of test is useful because it fails if we add arguments to the loader functions and forget to update its uses.
