### PR TITLE
Fixed Checkbox for 'Allow multiple terms' in the taxonomy panel, made it consistent with the rest of the UI

### DIFF
--- a/ui/static/ui/js/manage_taxonomies.jsx
+++ b/ui/static/ui/js/manage_taxonomies.jsx
@@ -281,11 +281,9 @@ define('manage_taxonomies', ['reactaddons', 'lodash', 'jquery', 'utils'],
           <p>
             <div className="checkbox">
               <label>
-                <input
-                  type="checkbox"
+                <ICheckbox
                   checked={this.state.multiTerms}
-                  onChange={thiz.updateMultiTerms} />
-                Allow multiple terms per learning resource
+                  onChange={thiz.updateMultiTerms} /> Allow multiple terms per learning resource
               </label>
             </div>
           </p>


### PR DESCRIPTION
Hi

In this PR I fixed style of a checkbox labeled as "Allow multiple terms" to make it consistent with the rest of the UI.

Issue https://github.com/mitodl/lore/issues/450
@pdpinch @carsongee @giocalitri 

![screen shot 2015-08-03 at 7 34 08 pm](https://cloud.githubusercontent.com/assets/10431250/9039741/f7266dec-3a16-11e5-98ef-3d0502d4b853.png)
