### PR TITLE
Fixed Checkbox for 'Allow multiple terms' in the taxonomy panel, made it consistent with the rest of the UI 

### DIFF
--- a/ui/static/ui/css/mit-lore.css
+++ b/ui/static/ui/css/mit-lore.css
@@ -208,6 +208,17 @@ a {
 	margin:2px 0 0 0;
 }
 
+.checkbox-add-vocabulary label {
+    min-height: 20px;
+    margin-bottom: 0;
+    font-weight: normal;
+    cursor: pointer;
+}
+
+.checkbox-add-vocabulary label span:after {
+    content: "\00a0";
+}
+
 /* results */
 .col-results {
 	border-left:1px dashed #E3E6EA;

--- a/ui/static/ui/js/manage_taxonomies.jsx
+++ b/ui/static/ui/js/manage_taxonomies.jsx
@@ -279,13 +279,12 @@ define('manage_taxonomies', ['reactaddons', 'lodash', 'jquery', 'utils'],
             </div>
           </p>
           <p>
-            <div className="checkbox">
+            <div className="checkbox-add-vocabulary">
               <label>
-                <input
-                  type="checkbox"
+                <ICheckbox
                   checked={this.state.multiTerms}
                   onChange={thiz.updateMultiTerms} />
-                Allow multiple terms per learning resource
+                  Allow multiple terms per learning resource
               </label>
             </div>
           </p>


### PR DESCRIPTION
Hi

In this PR I fixed style of a checkbox labeled as "Allow multiple terms" to make it consistent with the rest of the UI.

Issue https://github.com/mitodl/lore/issues/450
@pdpinch @carsongee @giocalitri 

![screen shot 2015-08-03 at 7 34 08 pm](https://cloud.githubusercontent.com/assets/10431250/9039741/f7266dec-3a16-11e5-98ef-3d0502d4b853.png)
