### PR TITLE
Added loader and fixed scroll issue on save button press

### DIFF
--- a/ui/jstests/test_manage_taxonomies.jsx
+++ b/ui/jstests/test_manage_taxonomies.jsx
@@ -211,6 +211,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         errorMessage = message;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var afterMount = function(component) {
         var labels = React.addons.TestUtils.
         scryRenderedDOMComponentsWithTag(
@@ -260,8 +265,10 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             assert.equal(refreshCount, 0);
             React.addons.TestUtils.Simulate.click(saveButton);
             component.forceUpdate(function() {
+              assert.equal(loadedState, false);
               //after saved term using api
               waitForAjax(1, function() {
+                assert.equal(loadedState, true);
                 //term state reset
                 assert.equal(component.state.formatActionState, 'show');
                 // term is update in parent
@@ -392,6 +399,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             vocabulary={vocabulary}
             refreshFromAPI={refreshFromAPI}
             reportMessage={reportMessage}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -422,6 +430,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
       var refreshCount = 0;
       var refreshFromAPI = function() {
         refreshCount++;
+      };
+
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
       };
 
       var afterMount = function(component) {
@@ -481,7 +494,10 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
                 assert.equal(refreshCount, 0);
                 React.addons.TestUtils.Simulate.click(saveButton);
                 component.forceUpdate(function() {
+                  // Loader is spinning...
+                  assert.equal(loadedState, false);
                   waitForAjax(1, function() {
+                    assert.equal(loadedState, true);
                     assert.equal(component.state.label, "TestB");
                     assert.equal(
                       component.state.errorMessage, 'Unable to update term'
@@ -530,6 +546,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateTerm={updateTerm}
             vocabulary={vocabulary}
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -564,6 +581,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         refreshCount++;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var afterMount = function(component) {
         var deleteButton = React.addons.TestUtils.
           findRenderedDOMComponentWithClass(
@@ -573,8 +595,10 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         //select delete
         React.addons.TestUtils.Simulate.click(deleteButton);
         component.forceUpdate(function() {
+          assert.equal(loadedState, false);
           assert.equal(component.state.formatActionState, 'show');
           waitForAjax(1, function() {
+            assert.equal(loadedState, true);
             // term is delete in parent
             assert.equal(parentUpdateCount, 1);
             // listing was asked to refresh
@@ -593,6 +617,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             deleteTerm={deleteTerm}
             vocabulary={vocabulary}
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -629,6 +654,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         refreshCount++;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var afterMount = function(component) {
         var deleteButton = React.addons.TestUtils.
           findRenderedDOMComponentWithClass(
@@ -642,7 +672,9 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             component.state.errorMessage, ''
           );
           assert.equal(component.state.formatActionState, 'show');
+          assert.equal(loadedState, false);
           waitForAjax(1, function() {
+            assert.equal(loadedState, true);
             // check state of error message
             assert.equal(
               component.state.errorMessage, 'Unable to delete term.'
@@ -661,6 +693,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             deleteTerm={deleteTerm}
             vocabulary={vocabulary}
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -693,6 +726,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
       };
 
       var reportMessage = function() {};
+
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
 
       var refreshCount = 0;
       var refreshFromAPI = function() {
@@ -783,7 +821,9 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
                   React.addons.TestUtils.Simulate.keyUp(
                     textbox, {key: "Enter"}
                   );
+                  assert.equal(loadedState, false);
                   waitForAjax(1, function () {
+                    assert.equal(loadedState, true);
                     assert.equal(addTermCalled, 1);
                     done();
                   });
@@ -805,6 +845,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             addTerm={addTerm}
             repoSlug="repo"
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -838,12 +879,19 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         refreshCount++;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var afterMount = function(component) {
         // wait for calls to populate form
         var node = React.findDOMNode(component);
         var textbox = $(node).find("input")[0];
         React.addons.TestUtils.Simulate.keyUp(textbox, {key: "Enter"});
+        assert.equal(loadedState, false);
         waitForAjax(1, function () {
+          assert.equal(loadedState, true);
           assert.equal(addTermCalled, 0);
           // refreshFromAPI was never called
           assert.equal(refreshCount, 0);
@@ -864,6 +912,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             addTerm={addTerm}
             repoSlug="repo"
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -895,6 +944,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         errorMessage = message;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var editVocabulary = function() {};
       var afterMount = function(component) {
         assert.equal(
@@ -922,12 +976,16 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
               'input'
             );
           React.addons.TestUtils.Simulate.keyUp(textbox, {key: "Enter"});
-          waitForAjax(1, function() {
-            //test items
-            assert.equal(addTermCalled, 1);
-            // listing page was asked to update
-            assert.equal(refreshCount, 1);
-            done();
+          component.forceUpdate(function() {
+            assert.equal(loadedState, false);
+            waitForAjax(1, function () {
+              assert.equal(loadedState, true);
+              //test items
+              assert.equal(addTermCalled, 1);
+              // listing page was asked to update
+              assert.equal(refreshCount, 1);
+              done();
+            });
           });
         });
       };
@@ -940,6 +998,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             addTerm={addTerm}
             refreshFromAPI={refreshFromAPI}
             reportMessage={reportMessage}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -1168,6 +1227,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             learningResourceTypes={propLearningResourceTypes}
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1260,6 +1320,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             refreshFromAPI={refreshFromAPI}
             reportMessage={reportMessage}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1361,6 +1422,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             refreshFromAPI={refreshFromAPI}
             updateParent={updateParent}
             reportMessage={reportMessage}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1506,6 +1568,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             reportMessage={reportMessage}
             renderConfirmationDialog={renderConfirmationDialog}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1513,7 +1576,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
   );
 
   QUnit.test('Assert that if user cancels update vocabulary dialog, no change' +
-    'is made',
+    ' is made',
     function(assert) {
       assert.ok(AddVocabulary, "class object not found");
       var done = assert.async();
@@ -1591,6 +1654,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             );
             component.forceUpdate(function () {
               React.addons.TestUtils.Simulate.click(updateButton);
+              // Check that loader turns on and off.
               component.forceUpdate(function () {
                 waitForAjax(1, function () {
                   var expected = {
@@ -1626,6 +1690,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             reportMessage={reportMessage}
             renderConfirmationDialog={renderConfirmationDialog}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1743,6 +1808,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             reportMessage={reportMessage}
             renderConfirmationDialog={renderConfirmationDialog}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1833,6 +1899,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             refreshFromAPI={refreshFromAPI}
             updateParent={updateParent}
             reportMessage={reportMessage}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1925,6 +1992,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             refreshFromAPI={refreshFromAPI}
             reportMessage={reportMessage}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );

--- a/ui/static/ui/js/listing.js
+++ b/ui/static/ui/js/listing.js
@@ -256,7 +256,6 @@ define('listing',
 
         renderListingResources();
         return $.get(url).then(function(collection) {
-          pageLoaded = true;
           listingOptions = $.extend({}, listingOptions);
           listingOptions.resources = collection.results;
           listingOptions.facetCounts = collection.facet_counts;
@@ -270,13 +269,12 @@ define('listing',
               pageNum = 1;
             }
           }
-
-          renderListingResources();
         }).fail(function(error) {
-          pageLoaded = true;
-
           // Propagate error
           return $.Deferred().reject(error);
+        }).always(function() {
+          pageLoaded = true;
+          renderListingResources();
         });
       };
 

--- a/ui/static/ui/js/manage_taxonomies.jsx
+++ b/ui/static/ui/js/manage_taxonomies.jsx
@@ -118,6 +118,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         label: this.state.label,
         weight: this.props.term.weight
       };
+      thiz.props.setLoadedState(false);
       $.ajax({
         type: 'PATCH',
         url: API_ROOT_VOCAB_URL,
@@ -127,10 +128,12 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         thiz.setState({
           errorMessage: 'Unable to update term'
         });
-      }).done(function(term) {
+      }).then(function(term) {
         thiz.resetUtilityFeatures();
         thiz.props.updateTerm(thiz.props.vocabulary.id, term);
         thiz.props.refreshFromAPI();
+      }).always(function() {
+        thiz.props.setLoadedState(true);
       });
     },
     confirmedDeleteResponse: function(success) {
@@ -139,6 +142,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         var API_ROOT_VOCAB_URL = '/api/v1/repositories/' + this.props.repoSlug +
         '/vocabularies/' + this.props.vocabulary.slug + '/terms/' +
         this.props.term.slug + "/";
+        thiz.props.setLoadedState(false);
         $.ajax({
           type: 'DELETE',
           url: API_ROOT_VOCAB_URL,
@@ -147,9 +151,11 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           thiz.setState({
             errorMessage: 'Unable to delete term.'
           });
-        }).done(function() {
+        }).then(function() {
           thiz.props.deleteTerm(thiz.props.vocabulary.id, thiz.props.term);
           thiz.props.refreshFromAPI();
+        }).always(function() {
+          thiz.props.setLoadedState(true);
         });
       }
     }
@@ -169,6 +175,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           key={term.id}
           renderConfirmationDialog={thiz.props.renderConfirmationDialog}
           refreshFromAPI={thiz.props.refreshFromAPI}
+          setLoadedState={thiz.props.setLoadedState}
           />;
       });
 
@@ -232,6 +239,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
     confirmedDeleteResponse: function(success) {
       var thiz = this;
       if (success) {
+        this.props.setLoadedState(false);
         var vocab = this.props.vocabulary;
         var API_ROOT_VOCAB_URL = '/api/v1/repositories/' + this.props.repoSlug +
           '/vocabularies/' + vocab.slug + '/';
@@ -245,6 +253,8 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           thiz.props.deleteVocabulary(vocab.id);
 
           thiz.props.refreshFromAPI();
+        }).always(function() {
+          thiz.props.setLoadedState(true);
         });
       }
     },
@@ -266,6 +276,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
       var thiz = this;
       var API_ROOT_VOCAB_URL = '/api/v1/repositories/' + this.props.repoSlug +
         '/vocabularies/';
+      this.props.setLoadedState(false);
       $.ajax({
           type: "POST",
           url: API_ROOT_VOCAB_URL + this.props.vocabulary.slug + "/terms/",
@@ -276,20 +287,22 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           contentType: "application/json; charset=utf-8"
         }
       ).fail(function() {
-          thiz.props.reportMessage({
-            error: "Error occurred while adding new term."
-          });
-        })
-      .then(function(newTerm) {
-          thiz.props.addTerm(thiz.props.vocabulary.id, newTerm);
-          thiz.setState({
-            newTermLabel: null
-          });
-
-          // clear errors
-          thiz.props.reportMessage(null);
-          thiz.props.refreshFromAPI();
+        thiz.props.reportMessage({
+          error: "Error occurred while adding new term."
         });
+      })
+      .then(function(newTerm) {
+        thiz.props.addTerm(thiz.props.vocabulary.id, newTerm);
+        thiz.setState({
+          newTermLabel: null
+        });
+
+        // clear errors
+        thiz.props.reportMessage(null);
+        thiz.props.refreshFromAPI();
+      }).always(function() {
+        thiz.props.setLoadedState(true);
+      });
     },
     getInitialState: function() {
       return {
@@ -316,6 +329,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           addTerm={thiz.props.addTerm}
           renderConfirmationDialog={thiz.props.renderConfirmationDialog}
           refreshFromAPI={thiz.props.refreshFromAPI}
+          setLoadedState={thiz.props.setLoadedState}
           />;
       });
       return <div className="panel-group lore-panel-group">
@@ -399,6 +413,8 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         learning_resource_types: this.state.learningResourceTypes,
         multi_terms: this.state.multiTerms
       };
+
+      thiz.props.setLoadedState(false);
 
       // User wants to submit the form. First we need to see if any
       // resource term links would be deleted by this action. If so we need
@@ -506,6 +522,8 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           }
           thiz.props.reportMessage({error: error});
         }
+      }).always(function() {
+        thiz.props.setLoadedState(true);
       });
     },
     isEditModeOpen: function() {
@@ -755,8 +773,9 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         </ul>
         <div className="tab-content drawer-tab-content">
           <div className="tab-pane active" id="tab-taxonomies">
-            <ReactOverlayLoader loaded={this.state.loaded}
-                                hideChildrenOnLoad={true}>
+            <ReactOverlayLoader
+              loaded={this.state.loaded}
+              hideChildrenOnLoad={!this.state.showChildrenOnLoad}>
             <AddTermsComponent
               deleteTerm={this.deleteTerm}
               updateTerm={this.updateTerm}
@@ -769,12 +788,13 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
               addTerm={this.addTerm}
               message={this.state.termsMessage}
               reportMessage={this.termsReport}
+              setLoadedState={this.setLoadedState}
               />
             </ReactOverlayLoader>
           </div>
           <div className="tab-pane drawer-tab-content" id="tab-vocab">
             <ReactOverlayLoader loaded={this.state.loaded}
-              hideChildrenOnLoad={true}>
+              hideChildrenOnLoad={!this.state.showChildrenOnLoad}>
             <AddVocabulary
               editVocabulary={this.editVocabulary}
               updateParent={this.addOrUpdateVocabulary}
@@ -785,6 +805,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
               refreshFromAPI={this.props.refreshFromAPI}
               message={this.state.vocabMessage}
               reportMessage={this.vocabReport}
+              setLoadedState={this.setLoadedState}
               />
               </ReactOverlayLoader>
           </div>
@@ -798,10 +819,16 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
     termsReport: function(message) {
       this.setState({termsMessage: message});
     },
+    setLoadedState: function(loaded) {
+      this.setState({loaded: loaded});
+    },
     componentDidMount: function() {
       var thiz = this;
 
-      this.setState({loaded: false});
+      this.setState({
+        loaded: false,
+        showChildrenOnLoad: false
+      });
       Utils.getCollection("/api/v1/learning_resource_types/").then(
         function(learningResourceTypes) {
         if (!thiz.isMounted()) {
@@ -819,13 +846,15 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
             }
 
             thiz.setState({
-              vocabularies: vocabularies,
-              loaded: true
+              vocabularies: vocabularies
             });
           }
         );
-      }).fail(function() {
-        thiz.setState({loaded: true});
+      }).always(function() {
+        thiz.setState({
+          loaded: true,
+          showChildrenOnLoad: true
+        });
       });
     }
   });

--- a/ui/static/ui/js/utils.jsx
+++ b/ui/static/ui/js/utils.jsx
@@ -336,7 +336,7 @@ define("utils", ["jquery", "lodash", "react", "react_infinite", "spin",
       if (this.isMounted() && !this.props.loaded) {
         var target = React.findDOMNode(this.refs.loader);
 
-        var spinner = new Spinner();
+        var spinner = new Spinner({zIndex: 0});
         spinner.spin(target);
       }
     },


### PR DESCRIPTION
Hi

In this PR I have 
- Added a loader to both taxonomy panel and learning resource panel on save button click.
- After ajax call success/fail i scrolled up page to the **response message**. **Note** Only in case of success call in taxonomy  we switch tabs and scroll to new added vocabulary at bottom . 
- Fixed scroll issue on taxonomy and learning resource panels where previously we could scroll panels and background at same time (scroll overlapping issue)

fixes https://github.com/mitodl/lore/issues/439
@pdpinch @ShawnMilo @giocalitri 

![screen shot 2015-08-04 at 4 58 30 pm](https://cloud.githubusercontent.com/assets/10431250/9061637/8dec7e6e-3ad6-11e5-94c3-4302fcd61e28.png)

![screen shot 2015-08-04 at 6 20 27 pm](https://cloud.githubusercontent.com/assets/10431250/9061654/a14be602-3ad6-11e5-9640-071a9cfa61e8.png)

![screen shot 2015-08-04 at 6 19 59 pm](https://cloud.githubusercontent.com/assets/10431250/9061657/a9c9e3ec-3ad6-11e5-9a84-991f607ee608.png)
