### PR TITLE
Collapsed repository management buttons into a drop-down menu

### DIFF
--- a/ui/static/ui/css/mit-lore.css
+++ b/ui/static/ui/css/mit-lore.css
@@ -6,6 +6,7 @@
 
 *::after, *::before {
     content: '';
+    content: none;  /* for chrome and safari */
 }
 
 body {
@@ -509,4 +510,8 @@ ul.repos {
     list-style-type: none;
     padding: 0px;
     margin: 0px;
+}
+
+.dropdown-repository {
+    margin-left: 380px;
 }

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -75,7 +75,7 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle nav-highlight" data-toggle="dropdown" role="button" aria-expanded="false">{{ request.user.username }}<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="{% url "cas_logout" %}?next_page=/">Logout</a></li>
+                <li><a href="{% url "cas_logout" %}?next_page=/"><i class="fa fa-sign-out"></i> Logout</a></li>
                 {% block actions %}{% endblock %}
                 <!-- <li><a href="#">Action</a></li> -->
                 <!-- <li><a href="#">Another action</a></li> -->

--- a/ui/templates/repo_base.html
+++ b/ui/templates/repo_base.html
@@ -1,23 +1,32 @@
 {% extends "base.html" %}
 {% block nav %}
   {{ nav.super }}
-   	{% if 'import_course' in perms_on_cur_repo %}
- 	  <li>
- 	  	<a href="{% url 'upload' repo.slug %}"><i class="fa fa-arrow-circle-o-right"></i> Import Course</a>
- 	  </li>
- 	{% endif %}
-  	{% if 'manage_taxonomy' in perms_on_cur_repo %}
-      <li>
-        <a href="#0" class="btn-taxonomies"><i class="fa fa-cogs"></i> Manage Taxonomies</a>
-      </li>
-    {% endif %}
+    <div class="btn-group dropdown-repository">
+      <button type="button" class="btn btn-default">Repository Actions</button>
+      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span class="caret"></span>
+        <span class="sr-only">Toggle Dropdown</span>
+      </button>
+      <ul class="dropdown-menu">
+   	    {% if 'import_course' in perms_on_cur_repo %}
+ 	      <li>
+ 	    	<a href="{% url 'upload' repo.slug %}"><i class="fa fa-arrow-circle-o-right"></i> Import Course</a>
+          </li>
+ 	    {% endif %}
+  	    {% if 'manage_taxonomy' in perms_on_cur_repo %}
+          <li>
+            <a href="#0" class="btn-taxonomies"><i class="fa fa-cogs"></i> Manage Taxonomies</a>
+          </li>
+        {% endif %}
+        {% if 'manage_repo_users' in perms_on_cur_repo %}
+          <li>
+            <a href="#repo-members" class="btn-members"><i class="fa fa-users"></i> Manage Members</a>
+         </li>
+        {% endif %}
+      </ul>
       <input type="hidden" id="repo_slug" value="{{ repo.slug }}" />
-    {% if 'manage_repo_users' in perms_on_cur_repo %}
-      <li>
-        <a href="#repo-members" class="btn-members"><i class="fa fa-users"></i> Manage Members</a>
-      </li>
-    {% endif %}
-  {% endblock %}
+    <div>
+   {% endblock %}
 
   {% block extranavbarright %}
   <span class="text-repo-name">Repository: <a href="{% url 'repositories' repo.slug %}">{{ repo.name }}</a></span>


### PR DESCRIPTION
Hi

In this PR I
- Added logout icon in user menu
- I moved repository actions like Manage Taxonomies, Manage Members, Import Analytics to user menu.

https://github.com/mitodl/lore/issues/418
@pdpinch @Ferdi 

![screen shot 2015-08-06 at 6 43 57 pm](https://cloud.githubusercontent.com/assets/10431250/9113006/9f03f2fe-3c6b-11e5-9b9c-9f8ea8ad3eac.png)

![screen shot 2015-08-06 at 6 56 14 pm](https://cloud.githubusercontent.com/assets/10431250/9113233/d733e69c-3c6c-11e5-9342-b64736941b46.png)

![screen shot 2015-08-06 at 6 47 24 pm](https://cloud.githubusercontent.com/assets/10431250/9113031/bd2c3a84-3c6b-11e5-9733-37c17afece17.png)

![screen shot 2015-08-06 at 6 47 28 pm](https://cloud.githubusercontent.com/assets/10431250/9113034/c229b1ba-3c6b-11e5-919f-3e6adcd9ba0e.png)
