### PR TITLE
Added xanalytics icons to listing page

### DIFF
--- a/ui/static/ui/css/mit-lore.css
+++ b/ui/static/ui/css/mit-lore.css
@@ -341,6 +341,22 @@ a {
 	font-size:16px;
 }
 
+.sub-meta {
+    display: inline-block;
+    float: right;
+    width: 60%;
+    text-align: right;
+}
+
+.sub-meta .meta-item {
+    width: 65px;
+    text-align: left;
+}
+
+.sub-meta .meta-item.mi-col-4 {
+    width: 24px;
+}
+
 /* pagination */
 .lore-pagination {
 	padding:40px 0;

--- a/ui/templates/includes/learning_resource.html
+++ b/ui/templates/includes/learning_resource.html
@@ -48,7 +48,12 @@
         <div class="tile-meta">
           <span class="meta-item">{{ result.course }}</span>
           <span class="meta-item">{{ result.run }}</span>
-          <span class="meta-item"><a href="{{ result.preview_url }}" target="_blank">Preview</a></span>
+          <span class="sub-meta">
+            <span class="meta-item mi-col-1"><i class="fa fa-eye"></i> {{ result.nr_views }}</span>
+            <span class="meta-item mi-col-2"><i class="fa fa-edit"></i> {{ result.nr_attempts }}</span>
+            <span class="meta-item mi-col-3"><i class="fa fa-graduation-cap"></i> {{ result.avg_grade }}</span>
+            <span class="meta-item mi-col-4"><a href="{{ result.preview_url }}" target="_blank">Preview</a></span>
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added icons to xanalytics page. Some notes:
- this information is pulled from the database. We will probably want another PR to pull from elasticsearch instead
- All information is shown for each learning resource type. If this isn't appropriate please let me know which learning resource types will show what kinds of data
- No histogram
