### PR TITLE
Split builds and removed python 3.3 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ services:
 before_script:
   - sleep 10
 env:
-  - DATABASE_URL=postgres://postgres@localhost:5432/postgres
+  global:
+    - DATABASE_URL=postgres://postgres@localhost:5432/postgres
 install:
   - "pip install 'tox>=2.0.2,<3.0.0'"
   - pip install coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,js,docs
+envlist = py27,py34,js,docs
 skip_missing_interpreters = True
 skipsdist = True
 


### PR DESCRIPTION
As discussed in our team meeting, this removes the tests for python 3.3.  It also splits the tests onto different workers for each test environment so that the testing time should just be the maximum of the environments (currently 3.4).
