### PR TITLE
Revert template change for learningresource list

### DIFF
--- a/ui/static/ui/css/mit-lore.css
+++ b/ui/static/ui/css/mit-lore.css
@@ -251,11 +251,6 @@ a {
     padding: 0;
 }
 
-.tile-meta {
-	font-size:small;
-	color:#929292;
-}
-
 .tile {
     margin: 18px 0 18px 0;
 }
@@ -330,9 +325,8 @@ a {
 }
 
 .tile-meta {
-    font-size: 13px;
-    color: #666;
-    font-weight: 700;
+	font-size:small;
+	color:#929292;
 }
 
 .meta-item {

--- a/ui/static/ui/css/mit-lore.css
+++ b/ui/static/ui/css/mit-lore.css
@@ -251,6 +251,11 @@ a {
     padding: 0;
 }
 
+.tile-meta {
+	font-size:small;
+	color:#929292;
+}
+
 .tile {
     margin: 18px 0 18px 0;
 }
@@ -332,7 +337,7 @@ a {
 
 .meta-item {
     display: inline-block;
-    margin: 0 10px 0 0;
+    margin: 0 14px 0 0;
 }
 
 .meta-item .fa {


### PR DESCRIPTION
This should change the appearance of listed learning resources to before https://github.com/mitodl/lore/commit/0c2c414ed4a0ef5471584fd364360e2f93ebe966.
This is described in https://github.com/mitodl/lore/issues/490.
