### PR TITLE
Added missing migration.

### DIFF
--- a/learningresources/migrations/0014_learning_resource_related_name.py
+++ b/learningresources/migrations/0014_learning_resource_related_name.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+# pylint: skip-file
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0013_populate_description_path'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='learningresource',
+            name='course',
+            field=models.ForeignKey(related_name='resources', to='learningresources.Course'),
+        ),
+    ]


### PR DESCRIPTION
Evidently changing a related_name on a model requires migrations now.

Closes #495.
