### PR TITLE
Reduce workers per dyno to avoid memory issues

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,7 +1,7 @@
 [uwsgi]
 http-socket = :$(PORT)
 master = true
-processes = 10
+processes = 5
 die-on-term = true
 wsgi-file = lore/wsgi.py
 memory-report = true


### PR DESCRIPTION
As a result of this message:
![image](https://cloud.githubusercontent.com/assets/596029/9258473/c5f8cbce-41c9-11e5-809a-413c26276279.png)

I would like to reduce the worker count (I don't think we need 10).
