### PR TITLE
Added configuration option and heroku command to pre-compress assets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,15 @@ To run one-off commands, like shell, you can run
 ``docker-compose run web python manage.py shell`` or to create root
 user, etc.
 
+Currently in the development environment we compile JSX on every
+request, which at the time of this writing is about 5 seconds. If you
+want to disable this (because you are working just on python for
+example), you can add the line ``LORE_COMPRESS_ENABLED: True`` to
+`docker-compose.yml` under the web -> environment section of the file.
+The first request will then take 5 seconds, but subsequent ones will
+be subsecond.
+
+
 Adding an application
 =====================
 

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -eo pipefail
+indent() {
+    RE="s/^/       /"
+    [ $(uname) == "Darwin" ] && sed -l "$RE" || sed -u "$RE"
+}
+
+# Install node for compress to work
+NODE_VERSION=0.12.7
+NODE_BASENAME=node-v${NODE_VERSION}-linux-x64
+NODE_ARCHIVE="http://nodejs.org/dist/v${NODE_VERSION}/${NODE_BASENAME}.tar.gz"
+
+MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
+MANAGE_FILE=${MANAGE_FILE:2}
+
+# make a temp directory
+tempdir="$( mktemp -t node_XXXX )"
+rm -rf $tempdir
+mkdir -p $tempdir
+
+pushd $tempdir
+curl -s -L -o tmp-nodejs.tar.gz $NODE_ARCHIVE
+tar -zxvf tmp-nodejs.tar.gz > /dev/null
+rm tmp-nodejs.tar.gz
+popd
+
+mkdir -v -p $BUILD_DIR/.heroku/vendor
+pushd $BUILD_DIR/.heroku/vendor
+rm -rf node
+mv $tempdir/$NODE_BASENAME node
+popd
+
+ln -s -f ../../vendor/node/bin/node .heroku/python/bin/node
+ln -s -f ../../vendor/node/bin/node-waf .heroku/python/bin/node-waf
+ln -s -f ../../vendor/node/bin/npm .heroku/python/bin/npm
+
+# Run compress now that node is installed
+
+echo "-----> Compressing static files"
+python $MANAGE_FILE compress -f 2>&1 | indent
+
+echo

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -193,6 +193,8 @@ COMPRESS_PRECOMPILERS = (
     ('text/requirejs', 'requirejs.RequireJSCompiler'),
     ('text/jsx', 'node_modules/.bin/jsx < {infile} > {outfile}')
 )
+COMPRESS_OFFLINE = get_var('LORE_COMPRESS_OFFLINE', False)
+COMPRESS_ENABLED = get_var('LORE_COMPRESS_ENABLED', not DEBUG)
 
 # Statsd client config
 STATSD_HOST = get_var('LORE_STATSD_HOST', 'localhost')


### PR DESCRIPTION
FYI @mitodl/odl-engineering this adds a little doc and config option for disabling static assets from being built locally on every request, which can be handy if you are working on something that isn't JS/React.
