### PR TITLE
Fixed caching bug.

### DIFF
--- a/search/search_indexes.py
+++ b/search/search_indexes.py
@@ -68,7 +68,8 @@ def get_vocabs(course_id, resource_id, solo_update=False):
     # terms for that LearningResource. Otherwise, looking up the vocabularies
     # for that resource will refill the cache for the entire course. If there
     # is already a value, retain it.
-    resource_ids = LearningResource.objects.all().values_list('id', flat=True)
+    resource_ids = LearningResource.objects.filter(
+        course__id=course_id).values_list('id', flat=True)
     for resource_id in resource_ids:
         rkey = "vocab_cache_{0}".format(resource_id)
         cache.set(rkey, cache.get(rkey, {}))


### PR DESCRIPTION
Fixes #529.

The caching done in `get_vocabs` was initializing the cached value
for all LearningResources, not just those in the course being dealt with.
