### PR TITLE
WIP Feature/skm/512 search empty facet

### DIFF
--- a/learningresources/migrations/0015_backfill_curator_vocabularies.py
+++ b/learningresources/migrations/0015_backfill_curator_vocabularies.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.utils.text import slugify
+
+from taxonomy.signals import create_default_vocabulary
+
+# pylint: skip-file
+
+VOCAB_NAME = "curation status"
+EMPTY_VALUE = "--not set--"
+
+
+def backfill_curator_vocabs(apps, schema_editor):
+    """Backfill auto-generated vocabulary to existing repos."""
+    Repository = apps.get_model("learningresources", "Repository")
+    LearningResourceType = apps.get_model(
+        "learningresources", "LearningResourceType")
+    Vocabulary = apps.get_model("taxonomy", "Vocabulary")
+    learning_resource_types = LearningResourceType.objects.all()
+    for repo in Repository.objects.all().iterator():
+        if Vocabulary.objects.filter(
+            name=VOCAB_NAME, repository__id=repo.id).exists():
+            continue
+        vocab = Vocabulary.objects.create(
+            repository_id=repo.id,
+            name=VOCAB_NAME, description=VOCAB_NAME,
+            required=True, vocabulary_type='m',
+            weight=0, multi_terms=False,
+            slug=slugify("{0}_{1}_backfill".format(VOCAB_NAME, repo.id)),
+        )
+        for resource_type in learning_resource_types:
+            vocab.learning_resource_types.add(resource_type)
+        create_terms(apps, vocab.id)
+        backfill_resources(apps, repo.id)
+
+
+def create_terms(apps, vocab_id):
+    """Create the curation status terms for a newly-created Vocabulary."""
+    Term = apps.get_model("taxonomy", "Term")
+    labels = (
+        'ready to use', 'tagged', 'course information',
+        'discarded', 'hidden', EMPTY_VALUE,
+    )
+    for label in labels:
+        Term.objects.create(
+            vocabulary_id=vocab_id,
+            label=label,
+            slug=slugify("{0}_{1}_backfill".format(label, vocab_id)),
+            weight=0,
+        )
+
+
+def backfill_resources(apps, repo_id):
+    """Add terms to existing LearningResource instances."""
+    LearningResource = apps.get_model("learningresources", "LearningResource")
+    Term = apps.get_model("taxonomy", "Term")
+    empty_term = Term.objects.get(
+        vocabulary__repository__id=repo_id,
+        vocabulary__name=VOCAB_NAME,
+        label=EMPTY_VALUE,
+    )
+    resources = LearningResource.objects.filter(
+        course__repository__id=repo_id
+    )
+    for resource in resources.iterator():
+        resource.terms.add(empty_term)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0014_learning_resource_related_name'),
+        ('taxonomy', '0007_vocabulary_multi_terms'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_curator_vocabs)
+    ]

--- a/learningresources/tests/test_models.py
+++ b/learningresources/tests/test_models.py
@@ -9,17 +9,20 @@ import string
 from shutil import rmtree
 from tempfile import mkdtemp
 
+from django.conf import settings
 from django.core.files import File
 from mock import MagicMock
 
 from .base import LoreTestCase
 from learningresources.models import (
     FILE_PATH_MAX_LENGTH,
+    LearningResource,
     LearningResourceType,
     Repository,
     static_asset_basepath,
     StaticAsset,
-    FilePathLengthException
+    FilePathLengthException,
+    get_preview_url,
 )
 
 
@@ -162,3 +165,28 @@ class TestModels(LoreTestCase):
                     asset=File(file_handle)
                 )
             )
+
+    def test_preview_url(self):
+        """
+        Test get_preview_url function. It returns different results depending
+        upon whether property url_name is None.
+        """
+        base_url = "{0}courses/org/".format(settings.LORE_PREVIEW_BASE_URL)
+        resource = LearningResource()
+
+        kwargs = {
+            'resource': resource,
+            'org': "org",
+            'course_number': 'babelfish',
+            'run': 'gazelle',
+        }
+
+        tests = (
+            (None, '{0}babelfish/gazelle/courseware'.format(base_url)),
+            ("WNYX", '{0}babelfish/gazelle/jump_to_id/WNYX'.format(base_url))
+        )
+
+        for url_name, wanted in tests:
+            resource.url_name = url_name
+            url = get_preview_url(**kwargs)
+            self.assertEqual(url, wanted)

--- a/rest/serializers.py
+++ b/rest/serializers.py
@@ -30,7 +30,8 @@ from learningresources.models import (
     LearningResource,
     StaticAsset,
     LearningResourceType,
-    STATIC_ASSET_BASEPATH
+    STATIC_ASSET_BASEPATH,
+    get_preview_url as resource_preview_url,
 )
 
 
@@ -244,7 +245,7 @@ class LearningResourceSerializer(ModelSerializer):
     @staticmethod
     def get_preview_url(obj):
         """Construct preview URL for LearningResource."""
-        return obj.get_preview_url()
+        return resource_preview_url(obj)
 
 
 class StaticAssetSerializer(ModelSerializer):

--- a/rest/tests/base.py
+++ b/rest/tests/base.py
@@ -4,6 +4,7 @@ LORE test case
 
 from __future__ import unicode_literals
 import json
+import logging
 
 from rest_framework.status import (
     HTTP_200_OK,
@@ -23,6 +24,8 @@ from roles.permissions import GroupTypes
 
 API_BASE = '/api/v1/'
 REPO_BASE = '/api/v1/repositories/'
+
+log = logging.getLogger(__name__)
 
 
 def as_json(resp):
@@ -199,6 +202,7 @@ class RESTTestCase(LoreTestCase):
                 repo_base=REPO_BASE,
             ), vocab_dict)
         self.assertEqual(expected_status, resp.status_code)
+
         if resp.status_code == HTTP_201_CREATED:
             result_dict = as_json(resp)
             if not skip_assert:
@@ -528,7 +532,7 @@ class RESTTestCase(LoreTestCase):
             result_dict = as_json(resp)
             if not skip_assert:
                 for key, value in lr_dict.items():
-                    self.assertEqual(value, result_dict[key])
+                    self.assertEqual(sorted(value), sorted(result_dict[key]))
             return result_dict
 
     def put_learning_resource(

--- a/rest/tests/test_learning_resource.py
+++ b/rest/tests/test_learning_resource.py
@@ -5,6 +5,8 @@ REST tests for LearningResources and static assets
 from __future__ import unicode_literals
 import os
 
+from django.utils.text import slugify
+
 from rest_framework.status import (
     HTTP_200_OK,
     HTTP_400_BAD_REQUEST,
@@ -25,9 +27,10 @@ from learningresources.models import (
     LearningResource,
     LearningResourceType,
     Repository,
+    get_preview_url,
 )
 from importer.tasks import import_file
-from taxonomy.models import Vocabulary
+from taxonomy.models import Vocabulary, Term
 from roles.permissions import GroupTypes
 from roles.api import assign_user_to_repo_group
 
@@ -166,8 +169,10 @@ class TestLearningResource(RESTTestCase):
         unsupported_term_slug = self.create_term(
             self.repo.slug, vocab2_slug)['slug']
 
-        self.assertEqual([], self.get_learning_resource(
-            self.repo.slug, lr_id)['terms'])
+        self.assertEqual(
+            [slugify(Term.EMPTY_VALUE)],
+            self.get_learning_resource(self.repo.slug, lr_id)['terms']
+        )
 
         self.patch_learning_resource(
             self.repo.slug, lr_id, {"terms": [supported_term_slug]})
@@ -263,7 +268,7 @@ class TestLearningResource(RESTTestCase):
         )
         self.assertEqual(
             expected_jump_to_id_url,
-            learning_resource.get_preview_url()
+            get_preview_url(learning_resource)
         )
 
         resource_dict = self.get_learning_resource(
@@ -275,7 +280,7 @@ class TestLearningResource(RESTTestCase):
         self.assertEqual(
             "https://www.sandbox.edx.org/courses/"
             "test-org/infinity/Febtober/courseware",
-            learning_resource.get_preview_url()
+            get_preview_url(learning_resource)
         )
 
     def test_learning_resource_exports_invalid_methods(self):

--- a/rest/tests/test_repository.py
+++ b/rest/tests/test_repository.py
@@ -83,9 +83,12 @@ class TestRepository(RESTTestCase):
         repositories = self.get_repositories()
         self.assertEqual(2, repositories['count'])
 
+        original_count = self.get_vocabularies(self.repo.slug)['count']
         vocab_slug = self.create_vocabulary(self.repo.slug)['slug']
-        vocabularies = self.get_vocabularies(self.repo.slug)
-        self.assertEqual(1, vocabularies['count'])
+        self.assertEqual(
+            original_count + 1,
+            self.get_vocabularies(self.repo.slug)['count']
+        )
 
         self.delete_repository(self.repo.slug,
                                expected_status=HTTP_405_METHOD_NOT_ALLOWED)
@@ -93,7 +96,7 @@ class TestRepository(RESTTestCase):
         self.delete_vocabulary(self.repo.slug, vocab_slug)
 
         vocabularies = self.get_vocabularies(self.repo.slug)
-        self.assertEqual(0, vocabularies['count'])
+        self.assertEqual(original_count, vocabularies['count'])
 
         self.delete_repository(self.repo.slug,
                                expected_status=HTTP_405_METHOD_NOT_ALLOWED)

--- a/roles/signals.py
+++ b/roles/signals.py
@@ -3,11 +3,15 @@ Signals handlers
 """
 from __future__ import unicode_literals
 
+import logging
+
 from django.db.models.signals import post_migrate, post_save
 from django.dispatch import receiver
 
-from learningresources.models import Repository
+from learningresources.models import Repository, repo_created
 from roles.utils import sync_groups_permissions
+
+log = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-argument
@@ -41,3 +45,6 @@ def add_creator_permission(sender, **kwargs):
         instance,
         GroupTypes.REPO_ADMINISTRATOR,
     )
+    # This signal is only fired upon initial creation of a repository,
+    # so receivers don't have to check whether the repository is new.
+    repo_created.send(sender=instance)

--- a/roles/tests/test_api.py
+++ b/roles/tests/test_api.py
@@ -92,24 +92,6 @@ class TestRoleApi(LoreTestCase):
             sorted(RepoPermission.author_permissions())
         )
 
-    def test_roles_init_new_repo_fake_permission_admin(self):
-        """
-        Non existing permissions for admin
-        """
-        with patch.object(api.RepoPermission,
-                          'administrator_permissions') as mock_method:
-            mock_method.return_value = ['fake_permission']
-            repo = create_repo(
-                name=self.repo_name,
-                description=self.repo_desc,
-                user_id=self.user.id,
-            )
-            admin = Group.objects.get(name=self.group_admin)
-            self.assertListEqual(
-                get_perms(admin, repo),
-                []
-            )
-
     def test_roles_init_new_repo_fake_permission_curator(self):
         """
         Non existing permissions for curator

--- a/search/tests/test_search_view.py
+++ b/search/tests/test_search_view.py
@@ -43,7 +43,7 @@ class TestSearchView(SearchTestCase):
         """
         Search should not load LearningResources from the database.
         """
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             resp = self.client.get(
                 reverse("repositories", args=(self.repo.slug,)))
 

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -1,0 +1,5 @@
+"""
+Ensure signals are registered.
+"""
+
+from taxonomy import signals

--- a/taxonomy/api.py
+++ b/taxonomy/api.py
@@ -52,3 +52,32 @@ def get_term(repo_slug, user_id, vocab_slug, term_slug):
         raise NotFound()
     except Term.DoesNotExist:
         raise NotFound()
+
+
+# pylint: disable=too-many-arguments
+def create_vocabulary(
+        user_id, repo_slug, name, description,
+        required=False, vocabulary_type=Vocabulary.MANAGED, weight=0,
+        multi_terms=False):
+    """
+    Create a new vocabulary.
+    Args:
+        user_id (int): primary key of the User
+        repo_slug (unicode): slug of the repository
+        name (unicode): vocab name
+        description (unicode): vocab description
+        required (bool): is it required?
+        vocabulary_type (unicode): on of the Vocabulary.vocabulary_type options
+        weight (int): vocab weight
+        multi_terms (bool): multiple terms possible on one LearningResource
+    Returns:
+        vocab (Vocabulary)
+    """
+    repo = get_repo(repo_slug, user_id)
+    vocab = Vocabulary.objects.create(
+        repository_id=repo.id,
+        name=name, description=description,
+        required=required, vocabulary_type=vocabulary_type,
+        weight=weight, multi_terms=multi_terms
+    )
+    return vocab

--- a/taxonomy/models.py
+++ b/taxonomy/models.py
@@ -50,19 +50,30 @@ class Vocabulary(BaseModel):
     @transaction.atomic
     def save(self, *args, **kwargs):
         """Handle slugs."""
+        create_notset = False
         if self.id is None or self.name != get_object_or_404(
                 Vocabulary, id=self.id).name:
             slug = slugify(self.name)
             count = 1
+            if self.id is None:
+                create_notset = True
             while Vocabulary.objects.filter(slug=slug).exists():
                 slug = "{0}{1}".format(slugify(self.name), count)
                 count += 1
             self.slug = slug
-        return super(Vocabulary, self).save(*args, **kwargs)
+
+        super(Vocabulary, self).save(*args, **kwargs)
+        if create_notset:
+            Term.objects.create(
+                vocabulary=self, label=Term.EMPTY_VALUE, weight=0)
+        return self
 
 
 class Term(BaseModel):
     """Model for term table"""
+
+    EMPTY_VALUE = '--not set--'
+
     vocabulary = models.ForeignKey(Vocabulary)
     label = models.CharField(max_length=256)
     slug = models.CharField(max_length=256, unique=True)

--- a/taxonomy/signals/__init__.py
+++ b/taxonomy/signals/__init__.py
@@ -1,0 +1,76 @@
+"""
+Signals for the Taxonomy application.
+
+This file was created because we need to create the curator vocabulary
+when a new Repository is created, but we can't add it to
+Repository.save() because that would create a circular import.
+
+The custom "repo_created" signal was added because if we use
+post_sav" here, there is a race condition with the post_save
+in roles which adds admin permissions to a Repository to the user
+who created it. It is impossible to dictate the order in which
+signals will be executed, and there's even a "wontfix" ticket for it:
+https://code.djangoproject.com/ticket/16547
+"""
+
+import logging
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from learningresources.models import (
+    repo_created, Repository, LearningResource,
+)
+
+log = logging.getLogger(__name__)
+
+CURATION_VOCAB_NAME = "curation status"
+
+
+# pylint: disable=unused-argument
+@receiver(repo_created)
+def create_default_vocabulary(sender, **kwargs):
+    """
+    Create the default curator vocabulary when a repository
+    is created.
+    """
+    if not isinstance(sender, Repository):
+        return
+    from taxonomy.utils import create_curator_vocabulary
+    from learningresources.models import LearningResourceType
+    vocabulary = create_curator_vocabulary(
+        repo_slug=sender.slug,
+        user_id=sender.created_by.id,
+        name=CURATION_VOCAB_NAME,
+        description=CURATION_VOCAB_NAME,
+    )
+    for resource_type in LearningResourceType.objects.all():
+        vocabulary.learning_resource_types.add(resource_type)
+
+
+@receiver(post_save)
+def add_default_curation_term(sender, **kwargs):
+    """
+    Add the default curation term to each newly-created LearningResource.
+    """
+    if kwargs["created"] is False:
+        return
+    instance = kwargs["instance"]
+    if not isinstance(instance, LearningResource):
+        return
+    from taxonomy.models import Term
+    terms = Term.objects.filter(
+        vocabulary__repository__id=instance.course.repository_id,
+        vocabulary__name=CURATION_VOCAB_NAME,
+        label=Term.EMPTY_VALUE,
+    )
+    if terms.count() != 1:
+        log.error(
+            (
+                "Unable to add default curation status value to "
+                "learning resource pk %s. Expected 1 matching "
+                "term, found %s."
+            ), instance.id, terms.count()
+        )
+        return
+    instance.terms.add(terms[0])

--- a/taxonomy/tests/test_models.py
+++ b/taxonomy/tests/test_models.py
@@ -4,8 +4,24 @@ Tests for taxonomy models
 
 from __future__ import unicode_literals
 
-from taxonomy.models import Vocabulary
+import logging
+
+from taxonomy.models import Vocabulary, Term
+from learningresources.api import create_repo, create_resource
 from learningresources.tests.base import LoreTestCase
+
+log = logging.getLogger(__name__)
+
+
+def get_vocabularies(repository_id):
+    """
+    Get all vocabularies for a repository.
+    Args:
+        repository_id (int): primary key of Repository
+    Returns:
+        repositories (list of Vocabulary)
+    """
+    return [x for x in Vocabulary.objects.filter(repository__id=repository_id)]
 
 
 class TestModels(LoreTestCase):
@@ -34,3 +50,40 @@ class TestModels(LoreTestCase):
         vocab.save()
         self.assertEqual(vocab.name, "vocab name")
         self.assertEqual(vocab.slug, "vocab-name")
+
+
+class TestCuratorVocabulary(LoreTestCase):
+    """
+    Tests for the automatically-created curator vocabulary.
+    """
+    def test_vocab_created(self):
+        """
+        A Repository should have the "curation status" vocabulary added
+        automatically upon creation.
+        """
+        repo = create_repo(
+            name="Ford Prefect",
+            description="Mostly harmless.",
+            user_id=self.user.id
+        )
+        self.assertEqual(len(get_vocabularies(repo.id)), 1)
+
+    def test_new_resource(self):
+        """
+        When a new LearningResource is created, it should automatically
+        have the default (not set) value of the curator status vocabulary.
+        """
+        resource = create_resource(
+            course=self.course,
+            parent=None,
+            resource_type="problem",
+            title="newly created",
+            content_xml="<xml/>",
+            mpath="",
+            url_name="",
+            dpath="",
+        )
+        # Should have the
+        terms = resource.terms.all()
+        self.assertEqual(terms.count(), 1)
+        self.assertEqual(terms[0].label, Term.EMPTY_VALUE)

--- a/taxonomy/utils/__init__.py
+++ b/taxonomy/utils/__init__.py
@@ -1,0 +1,43 @@
+"""
+Utilities for the taxonomy application.
+"""
+
+import logging
+
+from django.utils.text import slugify
+
+log = logging.getLogger(__name__)
+
+
+def create_curator_vocabulary(repo_slug, user_id, name, description):
+    """
+    Create the default "curator" vocabulary for a repository.
+    Args:
+        repo_slug (unicode): slug of the repository
+        user_id (int): primary key of the User
+        name (unicode): vocab name
+        description (unicode): vocab description
+
+    Returns:
+        vocab (Vocabulary)
+    """
+    from taxonomy.api import create_vocabulary
+    from taxonomy.models import Term
+    vocabulary = create_vocabulary(
+        user_id=user_id,
+        repo_slug=repo_slug,
+        name=name,
+        description=description,
+    )
+    labels = (
+        'ready to use', 'tagged', 'course information',
+        'discarded', 'hidden',
+    )
+    for label in labels:
+        Term.objects.create(
+            vocabulary_id=vocabulary.id,
+            label=label,
+            slug=slugify("{0}_{1}_auto".format(label, vocabulary.id)),
+            weight=0,
+        )
+    return vocabulary

--- a/ui/views.py
+++ b/ui/views.py
@@ -172,8 +172,18 @@ def get_vocabularies(facets):
             continue
         vocab = (vocabulary_id, vocabs[int(vocabulary_id)])
         vocabularies[vocab] = []
+        notset = None
         for t_id, count in term_data:
-            vocabularies[vocab].append((t_id, terms[int(t_id)], count))
+            # Save this for last if it exists.
+            if terms[int(t_id)] == Term.EMPTY_VALUE:
+                notset = (t_id, terms[int(t_id)], count)
+            else:
+                vocabularies[vocab].append((t_id, terms[int(t_id)], count))
+        # By default, sort alphabetically.
+        vocabularies[vocab].sort(key=lambda x: x[1])
+        # Add "not set" value after alphabetized values.
+        if notset is not None:
+            vocabularies[vocab].append(notset)
     return vocabularies
 
 


### PR DESCRIPTION
Done: Add a "not set" default to every vocabulary when it is created. This can be used for seeing counts of and filtering down to `LearningResource`s that haven't yet been assigned metadata.

WIP. Next steps:
- ability to filter on the "not set" value
- automatically remove "not set" value when any other term is added (good catch, @pdpinch)

This is a part of Epic #512.
