### PR TITLE
Made better navigation of paging in search results

### DIFF
--- a/ui/static/ui/css/mit-lore.css
+++ b/ui/static/ui/css/mit-lore.css
@@ -535,3 +535,22 @@ ul.repos {
     padding: 0px;
     margin: 0px;
 }
+
+.repo-page-status {
+    white-space: nowrap;
+    cursor: pointer;
+    display: inline;
+    font-size: 25px;
+    position: relative;
+    top: 27%;
+    transform: translateY(-27%);
+}
+
+input.repo-page-status {
+    width: 7%;
+    display: inline;
+    font-size: medium;
+    position: relative;
+    top: 27%;
+    transform: translateY(-27%);
+}

--- a/ui/templates/repository.html
+++ b/ui/templates/repository.html
@@ -69,6 +69,9 @@
         <i class="fa fa-angle-left"></i>
       </a>
       {% endif %}
+      <a id="repo_page_status" class="repo-page-status" data-page-num="{{ page.number }}" data-max-page-num="{{ page.paginator.num_pages }}">
+          Page {{ page.number }} of {{ page.paginator.num_pages }}
+      </a>
       {% if page.has_next %}
       <a href="{% url 'repositories' repo.slug %}{{ qs_prefix}}page={{ page.next_page_number }}&sortby={{ sorting_options.current.0 }}">
         <i class="fa fa-angle-right"></i>


### PR DESCRIPTION
In this PR I added
- Current page and max page information to pagination widget
- On Clicking widget a text field appears. User can enter any page number greater the 0 and less then current page.
- On press enter button user will be navigate to the newly entered page. If page number is valid
- On focus out user will be navigate to the newly entered page. If page number is valid 
- If user do not change page nothing happen, he can exit navigation text field by focus out or pressing enter key

Issue https://github.com/mitodl/lore/issues/513
@pdpinch @giocalitri 

![screen shot 2015-08-19 at 5 01 51 pm](https://cloud.githubusercontent.com/assets/10431250/9355705/ee121b0e-4694-11e5-9712-d92145cc8a8e.png)

![screen shot 2015-08-19 at 5 01 55 pm](https://cloud.githubusercontent.com/assets/10431250/9355713/f9b3b1ac-4694-11e5-9b35-27caba45de28.png)

![screen shot 2015-08-19 at 5 02 04 pm](https://cloud.githubusercontent.com/assets/10431250/9355712/f9b39a50-4694-11e5-84a7-2c6b8511bd5c.png)

![screen shot 2015-08-19 at 5 02 16 pm](https://cloud.githubusercontent.com/assets/10431250/9355714/f9b48730-4694-11e5-9e6d-8f01eebd4e2f.png)
