### PR TITLE
Added bootstrap as requirement for manage taxonomies

### DIFF
--- a/ui/static/ui/js/manage_taxonomies.jsx
+++ b/ui/static/ui/js/manage_taxonomies.jsx
@@ -1,4 +1,4 @@
-define('manage_taxonomies', ['react', 'lodash', 'jquery', 'utils'],
+define('manage_taxonomies', ['react', 'lodash', 'jquery', 'utils', 'bootstrap'],
   function (React, _, $, Utils) {
   'use strict';
 


### PR DESCRIPTION
The use of `$().tab()` in this file requires bootstrap. Depending on how tests are run this requirement may not be satisfied causing the tests to fail. At some point soon we should move that code into a callback passed via props so that it doesn't mess with the global test state, and so it's cleaner.
