### PR TITLE
Fixed migration to bulk create rows in through table

### DIFF
--- a/learningresources/migrations/0015_backfill_curator_vocabularies.py
+++ b/learningresources/migrations/0015_backfill_curator_vocabularies.py
@@ -64,8 +64,17 @@ def backfill_resources(apps, repo_id):
     resources = LearningResource.objects.filter(
         course__repository__id=repo_id
     )
-    for resource in resources.iterator():
-        resource.terms.add(empty_term)
+    ThroughModel = Term.learning_resources.through
+
+    to_insert = [
+        ThroughModel(
+            learningresource_id=resource.id,
+            term_id=empty_term.id,
+        ) for resource in resources.all()
+    ]
+
+    ThroughModel.objects.bulk_create(to_insert)
+
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
lore-ci is stuck because the migration is taking too long. This changes the insert to use `bulk_create` which will perform much more quickly
