### PR TITLE
Don't compress dynamic JavaScript

### DIFF
--- a/ui/templates/repository.html
+++ b/ui/templates/repository.html
@@ -86,6 +86,7 @@
 <script type="text/jsx"
         src="{% static "ui/js/utils.jsx" %}">
 </script>
+{% endcompress %}
 <script type="text/javascript">
 require(["listing", "jquery"], function(Listing, $) {
   var listingOptions = {
@@ -102,5 +103,4 @@ require(["listing", "jquery"], function(Listing, $) {
   });
 });
 </script>
-{% endcompress %}
 {% endblock %}


### PR DESCRIPTION
@noisecapella @pdpinch This fixes an issue which was introduced here:
https://github.com/mitodl/lore/commit/fb8c8d35943c47a6578093ec3cd9f4633851f8e1#diff-eb13f8d6d1b21d83f8ea931d7ab6d6f8R90

On lore-ci, when viewing repositories, 500s happen with this exception:

``` python
OfflineGenerationError: You have offline compression enabled but key "60213a7ffca6b1b8e45d3177b959fa2e" is missing from offline manifest. You may need to run "python manage.py compress".
```

We can expect to get this error when introducing highly dynamic template tags into the JS compression block. The manifest key is generated by the `django compress` management command when the post_compile hook is executed, so it's generated without a user context. Because the text in this script block is different depending on the user, django compress is generating a different key for each/no user, which is causing a key mismatch when the template is rendered.
