### PR TITLE
Formatted average grade as fixed width number

### DIFF
--- a/ui/static/ui/js/listing_resources.jsx
+++ b/ui/static/ui/js/listing_resources.jsx
@@ -132,7 +132,7 @@ define('listing_resources', ['react', 'jquery', 'lodash'],
                     </span>
                     <span className="meta-item mi-col-3">
                       <i className="fa fa-graduation-cap">
-                      </i> {resource.xa_avg_grade}
+                      </i> {resource.xa_avg_grade.toFixed(1)}
                     </span>
                     <span className="meta-item mi-col-4">
                       <a href={resource.preview_url} target="_blank">Preview</a>


### PR DESCRIPTION
Overlooked this minor detail. If you look at lore-rc vs lore-ci you can see that the average grade is not formatted the same way.
