### PR TITLE
rc/0.10.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,3 +142,9 @@ To build the sphinx documentation project, run:
 
 This will build it on your local machine and you should be able to
 point your browser at ``</path/to/lore/repo>/docs/_build/index.html``.
+
+RESTful API Documentation
+=========================
+
+LORE has a RESTful API that is documented on Apiary
+`http://docs.lore.apiary.io <http://docs.lore.apiary.io>`_ .

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,40 +1,82 @@
 Release Notes
 -------------
 
+Version 0.10.0
+==============
+
+- Added listing refresh after taxonomy changes.
+- Added React component for not tagged count.
+- Added link in README.rst to RESTful API doc on Apiary.
+- Point to specific version of xbundle.
+- Point to v0.3.1 of xbundle on Github.
+- Cleaned up form-based search code.
+- Changed behavior to use AJAX calls for listing page updates.
+- Fixed bug with sorting by title being case sensitive.
+- Installed history.js.
+- Added capability to facet by missing Vocabulary terms in REST API search.
+- Added inline editing feature for terms in taxonomy panel.
+- Added delete vocabulary in taxonomy panel.
+- Added sorting by title.
+- Added Roles module to Sphinx documentation.
+- Updated export to preserve static asset path.
+- Fixed serving of images in javascript tests.
+- Updated apiary docs for recent changes to API.
+- Added REST endpoint for search.
+- Created React component for pagination.
+- Formatted average grade as fixed width number.
+- Changed member list refresh to happen after AJAX success.
+- Refactored facet view as React component.
+- Added URI.js.
+- Fixed counter in learning resource exports panels header.
+- Fixed ordering of javascript variables due to stricter JSHint rules.
+- Disable SSL validation for a test which uses urltools.
+- Revert #540, add migration to revert related data migration.
+- Added travis-ci build notifications for Hipchat and Slack.
+- Don't compress dynamic JavaScript.
+- Fixed migration to bulk create rows in through table.
+- Refactored listing resources to use React.
+- Added bootstrap as requirement for manage taxonomies.
+- Created 'curation status' vocabulary.
+- Optimized Dockerfile to reduce build times.
+- Added support for free tagging for terms.
+- [requires.io] dependency update.
+
+
 Version 0.9.0
 =============
 
 - Stripped caching out of vocabularies during indexing.
 - Changed password hashing during tests.
-- Updated third party requirements
-- Made better navigation of paging in search results
+- Updated third party requirements.
+- Made better navigation of paging in search results.
 - Made creator of a repo an admin during repo creation.
-- Fixed static asset download for local servers
-- Added lazy loading of static asset information
-- Added icon for logout previously reverted
+- Fixed static asset download for local servers.
+- Added lazy loading of static asset information.
+- Added icon for logout previously reverted.
 
 Version 0.8.0
 =============
-- Changed how vocabulary terms are applied to Learning Resources to use two dropdowns instead of a growing list of fields.
-- Added deployment for release candidates
-- Added deploy button and app.json
+- Changed how vocabulary terms are applied to Learning Resources
+  to use two dropdowns instead of a growing list of fields.
+- Added deployment for release candidates.
+- Added deploy button and app.json.
 - Fixed caching bug.
-- Fixed panel shade issue
-- Added base sorting field in case used sorting is working on same values
-- Removed response from PATCH on learning resource to aid in performance
-- Added configuration option and heroku command to pre-compress assets
-- Added Google Analytics tracking support Closes
-- Reduce workers per dyno to avoid memory issues
-- Added statsd and a few timers - Import timer - Index signal handler timers - Search page load time
+- Fixed panel shade issue.
+- Added base sorting field in case used sorting is working on same values.
+- Removed response from PATCH on learning resource to aid in performance.
+- Added configuration option and heroku command to pre-compress assets.
+- Added Google Analytics tracking support Closes.
+- Reduce workers per dyno to avoid memory issues.
+- Added statsd and a few timers.
 - Updated indexing caching from dict to Django's cache.
-- .tile-meta no longer defined twice
-- Split builds and removed python 3.3 testing
-- reverted tile-meta and meta-item for previous appearance
+- .tile-meta no longer defined twice.
+- Split builds and removed python 3.3 testing.
+- reverted tile-meta and meta-item for previous appearance.
 - Added import for (sample) xanalytics API data.
-- Added closing panels with ESC key
+- Added closing panels with ESC key.
 - Fixed export button to show up even without search results.
-- Updated CSS and HTML according to mockup changes
-- Added xanalytics icons to listing page
+- Updated CSS and HTML according to mockup changes.
+- Added xanalytics icons to listing page.
 - Added xanalytics management command.
 
 
@@ -44,7 +86,7 @@ Version 0.7.0
 - Implemented ``Select2`` element to refactor ``select2`` widgets.
 - Added checkboxes to allow user to uncheck items in export panel.
 - Sped up indexing using caching.
-- Made checkbox for ``Allow multiple terms`` in the taxonomy panel
+- Made checkbox for ``Allow multiple terms`` in the taxonomy panel.
   consistent with the rest of the UI.
 - Implemented export of static assets.
 - Fixed user menu display on LORE welcome page.
@@ -95,31 +137,32 @@ Version 0.5.0
 
 - Fixed display of vocabulary terms containing spaces.
 - Fixed comparison of FileFields to strings.
-- Fixed typo in search hint
+- Fixed typo in search hint.
 - Added bootstrap style to vocabulary learning type checkboxes Closes #337
-- Changed search box description
-- Fixed mutating of this.state which is forbidden
+- Changed search box description.
+- Fixed mutating of this.state which is forbidden.
 - Added static file parsing to HTML elements.
-- Removed vocabulary forms since we are doing this via REST API and React instead
-- Reported code coverage for javascript on the command line
-- Added function to obtain collections
-- Set QUnit timeout to fix test error reporting
-- Added HTML reporting of javascript tests
-- Added panel for static assets
-- Added link to request create repository permission
+- Removed vocabulary forms since we are doing this via REST API
+  and React instead.
+- Reported code coverage for javascript on the command line.
+- Added function to obtain collections.
+- Set QUnit timeout to fix test error reporting.
+- Added HTML reporting of javascript tests.
+- Added panel for static assets.
+- Added link to request create repository permission.
 
 Version 0.4.0
 =============
 
-- Added view to serve static assets and modified REST API
+- Added view to serve static assets and modified REST API.
 - Added fix and test for handling deleted Elasticsearch index.
-- Refactored manage_taxonomies.jsx and related tests
-- Sped up test discovery by removing node_modules from search
-- Added learning resource types to manage taxonomies UI
+- Refactored manage_taxonomies.jsx and related tests.
+- Sped up test discovery by removing node_modules from search.
+- Added learning resource types to manage taxonomies UI.
 - Added learning_resource_types API and learning_resource_types field for
-  vocabularies
-- Fixed bug with file path length in static assets
-- Added learning resource UI to edit description and terms
+  vocabularies.
+- Fixed bug with file path length in static assets.
+- Added learning resource UI to edit description and terms.
 - Upgraded several packages
     - Bootstrap
     - uwsgi
@@ -127,45 +170,45 @@ Version 0.4.0
     - elasticsearch
     - django-bootstrap
     - django-storages-redux
-- Added terms to the readonly list
-- Allowed blank descriptions for LearningResource model
+- Added terms to the readonly lists.
+- Allowed blank descriptions for LearningResource model.
 - Implemented Enter key to add taxonomy term and added test case to
-  fix coverage
+  fix coverage.
 - Updated Django to 1.8.3
-- Correct LORE production URL in Apiary doc
-- Added checkbox styling to vocabulary/term facets
-- Fixed error message on unsupported terms in learning resource
-- Fixed facet checkboxes not showing in production
-- Fixed course/run highlight bug
-- Default checked radio button for Manage Taxonomies -> Add Vocabulary
-- Fixed vertical alignment of taxonomy tabs
-- Fixed error message for duplicate vocabulary
-- Added docker container for javascript testing
-- Added checkboxes and ability to toggle facets
-- Added html coverage report for javascript
-- Added shim configuration to karma test runner
-- Implemented learning_resources API
-- Members REST API docs
+- Correct LORE production URL in Apiary doc.
+- Added checkbox styling to vocabulary/term facets.
+- Fixed error message on unsupported terms in learning resource.
+- Fixed facet checkboxes not showing in production.
+- Fixed course/run highlight bug.
+- Default checked radio button for Manage Taxonomies -> Add Vocabulary.
+- Fixed vertical alignment of taxonomy tabs.
+- Fixed error message for duplicate vocabulary.
+- Added docker container for javascript testing.
+- Added checkboxes and ability to toggle facets.
+- Added html coverage report for javascript.
+- Added shim configuration to karma test runner.
+- Implemented learning_resources API.
+- Members REST API docs.
 - Linked video transcripts to learning resources.
-- Parse static assets from LearningResource
-- Removed unused patterns to limit memory use
-- fix css to make list vertical align
-- Installed JSXHint and configured JSCS to work with JSX files
-- Included JSX files in coverage results
-- Allow only usernames and not emails in the Members add input
-- Added test case, tested menulay all scenarios
-- Moved coverage CLI script to utils directory
+- Parse static assets from LearningResource.
+- Removed unused patterns to limit memory use.
+- fix css to make list vertical align.
+- Installed JSXHint and configured JSCS to work with JSX files.
+- Included JSX files in coverage results.
+- Allow only usernames and not emails in the Members add input.
+- Added test case, tested menulay all scenarios.
+- Moved coverage CLI script to utils directory.
 - Fixed buttons alignment problem in members panel.
-- Fixed error message behavior for manage taxonomies tab
-- Added ability to filter vocabularies by learning resource type
+- Fixed error message behavior for manage taxonomies tab.
+- Added ability to filter vocabularies by learning resource type.
 
 Version 0.3.0
 =============
 
 - Added UI to add and remove repository members.
 - Added form for adding new vocabularies.
-- Added manage taxonomies panel and button
-- REST for repo members
+- Added manage taxonomies panel and button.
+- REST for repo members.
 - Implemented taxonomy model delete cascading.
 - Renamed "Copy to Clipboard" to "Select XML"
 - Setup JSX processing requirements.
@@ -203,28 +246,28 @@ Other Changes
 Version 0.1.0
 =============
 
-- Added taxonomy app with models
-- Add learning resources app
+- Added taxonomy app with models.
+- Added learning resources app.
 - Basic Import Functionality
 - CAS Integration
-- Added forms to taxonomy app
-- Added welcome page
+- Added forms to taxonomy app.
+- Added welcome page.
 - Logging support
-- Added sphinx documentation project
-- Added add and edit forms for vocabularies
-- Added listing page
-- Added base UI templates
-- Styled listing page
-- Added footer to listing page
-- Added link to repository in repository base template
-- Added support for asynchronous course imports
-- Added rest app with support for RESTful API
-- Added initial authorization support
-- Added login requirement for taxonomy app
-- Switched to using Django storage for course uploads
-- Switched to using Haystack/ElasticSearch for listing page
-- Protected course imports
-- Protected export view
-- Added faceted filtering
-- Added new manage repo users permission
+- Added sphinx documentation project.
+- Added add and edit forms for vocabularies.
+- Added listing page.
+- Added base UI templates.
+- Styled listing page.
+- Added footer to listing page.
+- Added link to repository in repository base template.
+- Added support for asynchronous course imports.
+- Added rest app with support for RESTful API.
+- Added initial authorization support.
+- Added login requirement for taxonomy app.
+- Switched to using Django storage for course uploads.
+- Switched to using Haystack/ElasticSearch for listing page.
+- Protected course imports.
+- Protected export view.
+- Added faceted filtering.
+- Added new manage repo users permission.
 - Fixed repository listing page to only show results for a single repo.

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -15,7 +15,7 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 import yaml
 
-VERSION = '0.9.0'
+VERSION = '0.10.0'
 
 CONFIG_PATHS = [
     os.environ.get('LORE_CONFIG', ''),

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ git+https://github.com/mitodl/django-guardian@de7ca5c39dfd0870067497f5843581e9cd
 git+https://github.com/mingchen/django-cas-ng@69463fe7c23f025be7165c2967f4ceb983d60472#egg=django-cas-ng==3.4.3-odl
 
 # Importer application requirements
-xbundle==0.3.0
+git+https://github.com/mitodl/xbundle@0e6d87b6d87bf0c366b3e87865df2327d57c6525#egg=xbundle
 git+https://github.com/gdub/python-archive.git@61b9afde21621a8acce964d3336a7fb5d2d07ca6#egg=python-archive==0.3.1-odl
 django-storages-redux==1.3
 python-magic==0.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ git+https://github.com/mitodl/django-guardian@de7ca5c39dfd0870067497f5843581e9cd
 git+https://github.com/mingchen/django-cas-ng@69463fe7c23f025be7165c2967f4ceb983d60472#egg=django-cas-ng==3.4.3-odl
 
 # Importer application requirements
-git+https://github.com/mitodl/xbundle@0e6d87b6d87bf0c366b3e87865df2327d57c6525#egg=xbundle
+git+https://github.com/mitodl/xbundle@0e6d87b6d87bf0c366b3e87865df2327d57c6525#egg=xbundle==0.3.1
 git+https://github.com/gdub/python-archive.git@61b9afde21621a8acce964d3336a7fb5d2d07ca6#egg=python-archive==0.3.1-odl
 django-storages-redux==1.3
 python-magic==0.4.6

--- a/rest/tests/test_search.py
+++ b/rest/tests/test_search.py
@@ -511,3 +511,16 @@ class TestSearch(RESTTestCase):
                 'run': {}
             }
         )
+
+        selected_missing_facets = self.get_results(
+            selected_facets=["_missing_:{v}_exact".format(v=vocab.id)]
+        )['selected_missing_facets']
+        self.assertEqual(
+            selected_missing_facets,
+            {
+                "{v}".format(v=vocab.id): True
+            }
+        )
+
+        selected_missing_facets = self.get_results()['selected_missing_facets']
+        self.assertEqual(selected_missing_facets, {})

--- a/rest/views.py
+++ b/rest/views.py
@@ -789,6 +789,22 @@ def calculate_selected_facets(selected_facet_params, facet_counts):
     return selected_facets
 
 
+def calculate_selected_missing_facets(selected_facet_params, facet_counts):
+    """
+    Given facet counts and the facet query parameters,
+    return a dictionary of selected 'not tagged' facets.
+    """
+    selected_missing_facets = {}
+
+    for counts in facet_counts.values():
+        facet_id = counts['facet']['key']
+        param = "_missing_:{facet}_exact".format(facet=facet_id)
+        if param in selected_facet_params:
+            selected_missing_facets[facet_id] = True
+
+    return selected_missing_facets
+
+
 class RepositorySearchList(GenericViewSet):
     """
     View of search results for repository search.
@@ -824,6 +840,10 @@ class RepositorySearchList(GenericViewSet):
         data = response.data
         data['facet_counts'] = facet_counts
         data['selected_facets'] = calculate_selected_facets(
+            self.request.GET.getlist('selected_facets'),
+            facet_counts
+        )
+        data['selected_missing_facets'] = calculate_selected_missing_facets(
             self.request.GET.getlist('selected_facets'),
             facet_counts
         )

--- a/ui/static/ui/js/listing.js
+++ b/ui/static/ui/js/listing.js
@@ -193,6 +193,7 @@ define('listing',
 
       // Will be set in refreshFromAPI
       var selectedFacets;
+      var selectedMissingFacets;
 
       var openResourcePanel = function(resourceId) {
         LearningResources.loader(
@@ -219,6 +220,7 @@ define('listing',
           listingOptions.resources = collection.results;
           listingOptions.facetCounts = collection.facet_counts;
           selectedFacets = collection.selected_facets;
+          selectedMissingFacets = collection.selected_missing_facets;
 
           numPages = Math.ceil(collection.count / listingOptions.pageSize);
           if (pageNum > numPages) {
@@ -240,19 +242,7 @@ define('listing',
         });
       };
 
-      /**
-       * Update queryMap with updated facet information, then refresh from API.
-       *
-       * @param facetId {String} Facet key
-       * @param valueId {String} Facet value
-       * @param selected {bool} Value for facet checkbox
-       *
-       * @returns {jQuery.Deferred} Promise which is resolved or rejected after
-       * refresh occurs.
-       */
-      var updateFacets = function(facetId, valueId, selected) {
-        var param = facetId + "_exact:" + valueId;
-
+      var updateFacetParam = function(param, selected) {
         queryMap = $.extend({}, queryMap);
         queryMap.page = undefined;
 
@@ -272,6 +262,28 @@ define('listing',
         }
 
         return refreshFromAPI();
+      };
+
+      /**
+       * Update queryMap with updated facet information, then refresh from API.
+       *
+       * @param facetId {String} Facet key
+       * @param valueId {String} Facet value
+       * @param selected {bool} Value for facet checkbox
+       *
+       * @returns {jQuery.Deferred} Promise which is resolved or rejected after
+       * refresh occurs.
+       */
+      var updateFacets = function(facetId, valueId, selected) {
+        var param = facetId + "_exact:" + valueId;
+
+        return updateFacetParam(param, selected);
+      };
+
+      var updateMissingFacets = function(facetId, selected) {
+        var param = "_missing_:" + facetId + "_exact";
+
+        return updateFacetParam(param, selected);
       };
 
       /**
@@ -308,7 +320,8 @@ define('listing',
       renderListingResources = function() {
         return ListingResources.loader(listingOptions,
         container, openExportsPanel, openResourcePanel,
-        updateFacets, selectedFacets, updateSort);
+        updateFacets, updateMissingFacets,
+          selectedFacets, selectedMissingFacets, updateSort);
       };
 
       /**

--- a/ui/static/ui/js/listing_resources.jsx
+++ b/ui/static/ui/js/listing_resources.jsx
@@ -51,6 +51,29 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
       }
     });
 
+    var MissingCount = React.createClass({
+      render: function() {
+        var id = "check-" + this.props.facetId + "-missing";
+        return <li>
+          <ICheckbox
+            id={id}
+            tabIndex="add"
+            className="icheck-11" onChange={this.handleChange}
+            checked={this.props.selected}
+            />
+          <label htmlFor={id}>
+            {this.props.label}
+          </label>
+          <span className="badge">
+            {this.props.count}
+          </span>
+        </li>;
+      },
+      handleChange: function(e) {
+        this.props.updateMissingFacets(this.props.facetId, e.target.checked);
+      }
+    });
+
     var FacetGroup = React.createClass({
       render: function() {
         var thiz = this;
@@ -61,12 +84,25 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
                         id={value.key}
                         count={value.count}
                         key={value.key}
-                        facetId={thiz.props.id}
+                        facetId={thiz.props.facet.key}
                         imageDir={thiz.props.imageDir}
                         updateFacets={thiz.props.updateFacets}
                         selected={selected}
             />;
         });
+
+        var missingFacet = null;
+        if (this.props.facet.missing_count) {
+          var selected = thiz.props.selectedMissingFacets[this.props.facet.key];
+
+          missingFacet = <MissingCount
+            count={this.props.facet.missing_count}
+            facetId={this.props.facet.key}
+            updateMissingFacets={this.props.updateMissingFacets}
+            selected={selected}
+            label={"not tagged"}
+            />;
+        }
 
         var collapseId = "collapse-" + this.props.id;
 
@@ -78,13 +114,14 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
                  data-parent="#accordion"
                  data-toggle="collapse"
                 >
-                {this.props.label}
+                {this.props.facet.label}
               </a>
             </h4>
           </div>
           <div className="panel-collapse collapse in" id={collapseId}>
             <div className="panel-body">
               <ul className="icheck-list">
+                {missingFacet}
                 {facets}
               </ul>
             </div>
@@ -99,7 +136,8 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
         var facets = [];
 
         var makeFacetGroup = function(values) {
-          if (!values.values.length) {
+          if (!values.values.length &&
+              !values.facet.missing_count) {
             return null;
           }
           var selectedFacets = {};
@@ -109,12 +147,13 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
 
           return <FacetGroup
             values={values.values}
-            label={values.facet.label}
-            id={values.facet.key}
+            facet={values.facet}
             key={values.facet.key}
             updateFacets={thiz.props.updateFacets}
+            updateMissingFacets={thiz.props.updateMissingFacets}
             imageDir={thiz.props.imageDir}
             selectedFacets={selectedFacets}
+            selectedMissingFacets={thiz.props.selectedMissingFacets}
             />;
         };
 
@@ -392,7 +431,9 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
             <div className="panel-group lore-panel-group">
               <Facets facetCounts={this.props.facetCounts}
                       updateFacets={this.props.updateFacets}
+                      updateMissingFacets={this.props.updateMissingFacets}
                       selectedFacets={this.props.selectedFacets}
+                      selectedMissingFacets={this.props.selectedMissingFacets}
                       imageDir={this.props.imageDir} />
             </div>
           </div>
@@ -405,14 +446,16 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
 
     return {
       loader: function(listingOptions, container, openExportsPanel,
-                       openResourcePanel, updateFacets, selectedFacets,
-                       updateSort) {
+                       openResourcePanel, updateFacets, updateMissingFacets,
+                       selectedFacets, selectedMissingFacets, updateSort) {
         return React.render(
           <ListingPage {...listingOptions}
                    openExportsPanel={openExportsPanel}
                    openResourcePanel={openResourcePanel}
                    updateFacets={updateFacets}
+                   updateMissingFacets={updateMissingFacets}
                    selectedFacets={selectedFacets}
+                   selectedMissingFacets={selectedMissingFacets}
                    updateSort={updateSort}
             />,
           container
@@ -427,7 +470,8 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
       ListingPage: ListingPage,
       FacetGroup: FacetGroup,
       Facet: Facet,
-      Facets: Facets
+      Facets: Facets,
+      MissingCount: MissingCount
     };
   }
 );


### PR DESCRIPTION
Release 0.10.0
- [ ] Added listing refresh after taxonomy changes
  [George Schneeloch](gschneel@mit.edu)
- [ ] Added React component for not tagged counts
  [George Schneeloch](gschneel@mit.edu)
- [x] Added link to RESTful API doc on Apiary
  [pwilkins](pwilkins@mit.edu)
- [ ] Point to specific version of xbundle.
  [Jamie Folsom](jamiefolsom@gmail.com)
- [ ] Point to v. 0.3.1 of xbundle on github.
  [Jamie Folsom](jamiefolsom@gmail.com)
- [ ] Cleaned up form-based search code
  [George Schneeloch](gschneel@mit.edu)
- [ ] Changed behavior to use AJAX calls for listing page updates
  [George Schneeloch](gschneel@mit.edu)
- [x] Fixed bug with sorting by title being case sensitive
  [Giovanni Di Milia](gdimilia@mit.edu)
- [ ] Installed history.js
  [George Schneeloch](gschneel@mit.edu)
- [ ] Added capability to facet by missing Vocabulary terms in REST API search
  [Giovanni Di Milia](gdimilia@mit.edu)
- [ ] Added inline editing feature for terms in taxonomy panel.
  [Amir Qayyum Khan](amir.qayyum.khan@gmail.com)
- [ ] Delete vocabulary in taxonomy panel
  [George Schneeloch](gschneel@mit.edu)
- [x] Added sorting by &quot;title&quot;
  [Giovanni Di Milia](gdimilia@mit.edu)
- [x] Added Roles module docstrings to documentation
  [pwilkins](pwilkins@mit.edu)
- [x] Updated export to preserve static asset path
  [George Schneeloch](gschneel@mit.edu)
- [x] Fixed serving of images in javascript tests
  [George Schneeloch](gschneel@mit.edu)
- [x] Updated apiary docs for recent changes to API
  [George Schneeloch](gschneel@mit.edu)
- [x] Added REST endpoint for search
  [George Schneeloch](gschneel@mit.edu)
- [ ] Created React component for pagination
  [George Schneeloch](gschneel@mit.edu)
- [x] Formatted average grade as fixed width number
  [George Schneeloch](gschneel@mit.edu)
- [x] Changed member list refresh to happen after AJAX success
  [George Schneeloch](gschneel@mit.edu)
- [x] Refactored facet view as React component
  [George Schneeloch](gschneel@mit.edu)
- [x] Added URI.js
  [George Schneeloch](gschneel@mit.edu)
- [ ] Fixed counter in learning resouce exports panels header
  [Amir Qayyum Khan](amir.qayyum.khan@gmail.com)
- [x] Fixed ordering of javascript variables due to stricter JSHint rules
  [George Schneeloch](gschneel@mit.edu)
- [ ] Disable SSL validation for a test which uses urltools.
  [Brandon DeRosier](x@bdero.me)
- [x] Revert #540, add migration to revert related data migration.
  [George Schneeloch](gschneel@mit.edu)
- [ ] Added travis-ci build notifications for Hipchat &amp; Slack
  [Brandon DeRosier](x@bdero.me)
- [ ] Don&#39;t compress dynamic JavaScript
  [Brandon DeRosier](x@bdero.me)
- [x] Fixed migration to bulk create rows in through table
  [George Schneeloch](gschneel@mit.edu)
- [x] Refactored listing resources to use React
  [George Schneeloch](gschneel@mit.edu)
- [x] Added bootstrap as requirement for manage taxonomies
  [George Schneeloch](gschneel@mit.edu)
- [ ] Created &quot;curation status&quot; vocabulary.
  [Shawn Milochik](shawn@milochik.com)
- [ ] Optimized Dockerfile to reduce build times.
  [Carson Gee](x@carsongee.com)
- [ ] Added support for free tagging for terms.
  [Giovanni Di Milia](gdimilia@mit.edu)
- [ ] [requires.io] dependency update.
  [requires.io](support@requires.io)
