### PR TITLE
Fixed exact repository search bug

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -4,7 +4,6 @@ Functions for search functionality.
 
 from __future__ import unicode_literals
 
-from haystack.inputs import Exact
 from haystack.query import SearchQuerySet
 
 from search.sorting import LoreSortingFields
@@ -40,7 +39,8 @@ def construct_queryset(repo_slug, query='', selected_facets=None, sortby=''):
 
     queryset = queryset.filter(**kwargs)
 
-    queryset = queryset.filter(repository=Exact(repo_slug))
+    queryset = queryset.narrow("repository_exact:{slug}".format(
+        slug=repo_slug))
 
     if sortby == "":
         sortby = LoreSortingFields.DEFAULT_SORTING_FIELD

--- a/search/tests/test_api.py
+++ b/search/tests/test_api.py
@@ -1,0 +1,37 @@
+"""
+Tests for search API functions.
+"""
+
+from __future__ import unicode_literals
+
+from importer.tasks import import_file
+from learningresources.api import create_repo
+from search.api import construct_queryset
+from search.tests.base import SearchTestCase
+
+
+class TestAPI(SearchTestCase):
+    """Test API."""
+
+    def import_course_tarball(self, repo):
+        """
+        Import course into repository.
+        """
+        tarball_file = self.get_course_single_tarball()
+        import_file(tarball_file, repo.id, self.user.id)
+
+    def test_repository_exact_match(self):
+        """
+        Test that repository slug matches exactly
+        """
+        test_repo = create_repo("test", "testing", self.user.id)
+        testing_repo = create_repo("testing", "testing", self.user.id)
+
+        # Should start off with nothing in testing_repo.
+        self.assertEqual(construct_queryset(test_repo.slug).count(), 0)
+        self.assertEqual(construct_queryset(testing_repo.slug).count(), 0)
+        self.import_course_tarball(test_repo)
+
+        # We imported into 'test' so 'testing' shouldn't contain anything.
+        self.assertTrue(construct_queryset(test_repo.slug).count() > 0)
+        self.assertEqual(construct_queryset(testing_repo.slug).count(), 0)


### PR DESCRIPTION
Fixes #653 

It looks like the search caught some repositories beyond what was expected, I think the filtering on repo slug wasn't an exact filter. I'm not sure what went wrong here, maybe a Haystack bug or a misinterpretation on my part. This changes the query formatting to what @ShawnMilo used in the older search code.
