### PR TITLE
Removed lib/ from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ develop-eggs/
 /dist/
 downloads/
 eggs/
-lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
This hides files inside all `lib` directories, it seems like the intention was to just hide certain build files. We can add those back on an as needed basis
