### PR TITLE
Adds elasticsearch-dsl and adds it alongside Haystack for now.

### DIFF
--- a/learningresources/api.py
+++ b/learningresources/api.py
@@ -212,7 +212,7 @@ def get_resources(repo_id):
         list (list of learningresources.LearningResource): List of resources
     """
     return LearningResource.objects.select_related(
-        "learning_resource_type").filter(
+        "learning_resource_type", "course__repository").filter(
             course__repository__id=repo_id).order_by("title")
 
 

--- a/learningresources/tests/base.py
+++ b/learningresources/tests/base.py
@@ -28,6 +28,7 @@ from learningresources.api import (
     update_description_path
 )
 from learningresources.models import Repository, StaticAsset
+from search.utils import clear_index, refresh_index
 
 log = logging.getLogger(__name__)
 # Using the md5 hasher speeds up tests.
@@ -86,6 +87,7 @@ class LoreTestCase(TestCase):
     def setUp(self):
         """set up"""
         super(LoreTestCase, self).setUp()
+        clear_index()
         self.user = User.objects.create_user(
             username=self.USERNAME, password=self.PASSWORD
         )
@@ -123,6 +125,7 @@ class LoreTestCase(TestCase):
         self.client = Client()
 
         self.login(username=self.USERNAME)
+        refresh_index()
 
     def tearDown(self):
         """Clean up Elasticsearch and static assets between tests."""
@@ -131,6 +134,8 @@ class LoreTestCase(TestCase):
         for key, _ in haystack.connections.connections_info.items():
             haystack.connections.reload(key)
         call_command('clear_index', interactive=False, verbosity=0)
+        clear_index()
+        refresh_index()
 
     def _make_archive(self, path, make_zip=False, ext=None):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ djangorestframework==3.2.2
 dj-database-url==0.3.0
 dj-static==0.0.6
 elasticsearch==1.6.0
+elasticsearch-dsl==0.0.8
 git+https://github.com/bpeschier/django-compressor-requirejs@889d5edc4f2acaa961c170084f1171c700649519#egg=githubdjango-compressor-requirejs-develop==0.4.1-odl
 psycopg2==2.6.1
 PyYAML==3.11

--- a/search/migrations/0001_initial.py
+++ b/search/migrations/0001_initial.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""
+This migration should be able to be copy-pasted exactly for any
+future changes to the mapping, with the exception of the dependencies, which
+should be updated.
+"""
+
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+from search.utils import create_mapping, index_resources
+
+# pylint: skip-file
+
+
+def create_learning_resource_mapping(apps, schema_editor):
+    create_mapping()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0016_revert_backfill'),
+        ('taxonomy', '0007_vocabulary_multi_terms'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_learning_resource_mapping)
+    ]

--- a/search/tests/base_es.py
+++ b/search/tests/base_es.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for search engine indexing.
+
+Note that this file started out as a copy
+of search/tests/base.py, and was modified to use
+the Elasticsearch and Elasticsearch-DSL libraries instead of Haystack.
+"""
+from __future__ import unicode_literals
+
+import logging
+
+from learningresources.tests.base import LoreTestCase
+from search.utils import search_index
+from search.sorting import LoreSortingFields
+from taxonomy.models import Term, Vocabulary
+
+log = logging.getLogger(__name__)
+
+
+class SearchTestCase(LoreTestCase):
+    """Test Elasticsearch indexing."""
+
+    def setUp(self):
+        """Create a vocabulary for our tests."""
+        super(SearchTestCase, self).setUp()
+        self.vocabulary = Vocabulary.objects.create(
+            repository_id=self.repo.id, name="difficulty",
+            description="difficulty", required=False, vocabulary_type="f",
+            weight=1
+        )
+        self.terms = [
+            Term.objects.create(
+                vocabulary_id=self.vocabulary.id, label=label, weight=1
+            )
+            for label in ("easy", "medium", "very difficult", "ancòra", "very")
+        ]
+
+    def search(self, query, sorting=LoreSortingFields.DEFAULT_SORTING_FIELD):
+        """
+        Helper function to perform a search
+        """
+        return search_index(query, repo_slug=self.repo.slug, sort_by=sorting)
+
+    def count_results(self, query=None):
+        """Return count of matching indexed records."""
+        return self.search(query).count()
+
+    def count_faceted_results(self, vocab, term):
+        """Return count of matching indexed records by facet."""
+        return search_index(
+            repo_slug=self.repo.slug,
+            terms={vocab: term}
+        ).count()

--- a/search/tests/test_es_indexing.py
+++ b/search/tests/test_es_indexing.py
@@ -1,0 +1,257 @@
+"""
+Tests for Elasticsearch indexing.
+
+Note that this file started out as a copy
+of search/tests/test_indexing.py, and was modified to use
+the Elasticsearch and Elasticsearch-DSL libraries instead of Haystack.
+"""
+
+from __future__ import unicode_literals
+
+import logging
+
+from learningresources.tests.base import LoreTestCase
+from learningresources.models import LearningResource
+from importer.api import import_course_from_file
+from search.search_indexes import cache
+from search.sorting import LoreSortingFields
+from search.tests.base_es import SearchTestCase
+from search.utils import index_resources, search_index, refresh_index
+
+log = logging.getLogger(__name__)
+
+
+def set_cache_timeout(seconds):
+    """Override the cache timeout for testing."""
+    cache.default_timeout = seconds
+    cache.clear()
+
+
+class TestImport(LoreTestCase):
+    """
+    Test indexing on import.
+    """
+    def setUp(self):
+        """
+        Return location of the local copy of the "simple" course for testing.
+        """
+        super(TestImport, self).setUp()
+        self.course_zip = self.get_course_zip()
+
+    def test_import(self):
+        """
+        Indexing should occur on course import.
+        """
+        results = search_index()
+        original_count = results.count()
+        import_course_from_file(self.course_zip, self.repo.id, self.user.id)
+        refresh_index()
+        results = search_index()
+        self.assertEqual(results.count(), original_count + 18)
+        self.assertEqual(results.page_count(), 2)
+
+        # Ensure the correct number of results are returned in each page.
+        self.assertEqual(len(results.get_page(1)), 10)
+        self.assertEqual(len(results.get_page(2)), 9)
+        self.assertEqual(len(results.get_page(3)), 0)
+
+        # Make sure the .all() function (a convenience function which
+        # returns a generator), returns all the records without explicit
+        # pagination.
+        count = 0
+        for _ in results.all():
+            count += 1
+        self.assertEqual(count, results.count())
+
+    def test_update(self):
+        """
+        Items should only be indexed on update, not creation.
+
+        During course import, a bulk indexing will occur.
+        """
+        orig_count = search_index().count()
+        new_resource = LearningResource.objects.create(
+            course=self.resource.course,
+            learning_resource_type=self.resource.learning_resource_type,
+            title="accordion music",
+            content_xml="<blah>foo</blah>",
+            materialized_path="/foo",
+            url_name="url_name2",
+        )
+        self.assertEqual(search_index().count(), orig_count)  # no indexing
+        new_resource.save()  # triggers post_save signal with created=False
+        self.assertEqual(search_index().count(), orig_count + 1)
+
+    def test_search_fields(self):
+        """
+        The content_xml, title, and description should be searchable
+        by partial matches.
+        """
+        new_resource = LearningResource.objects.create(
+            course=self.resource.course,
+            learning_resource_type=self.resource.learning_resource_type,
+            title="accordion music",
+            content_xml="<blah>foo</blah>",
+            materialized_path="/foo",
+            url_name="url_name2",
+            description="the quick brown fox",
+            description_path="silver",
+        )
+
+        new_resource.save()  # to trigger indexing
+        refresh_index()
+
+        self.assertEqual(search_index("accordion").count(), 1)
+        self.assertEqual(search_index("fox brown").count(), 1)
+        self.assertEqual(search_index("foo").count(), 1)
+
+    def test_delete(self):
+        """
+        Items should be removed from the index when they are deleted.
+
+        """
+        orig_count = search_index().count()
+        self.resource.delete()
+        self.assertEqual(search_index().count(), orig_count - 1)
+
+
+class TestIndexing(SearchTestCase):
+    """Test Elasticsearch indexing."""
+
+    def setUp(self):
+        """Remember old caching settings."""
+        super(TestIndexing, self).setUp()
+        self.original_timeout = cache.default_timeout
+
+    def tearDown(self):
+        """Restore old caching settings."""
+        super(TestIndexing, self).tearDown()
+        cache.default_timeout = self.original_timeout
+
+    def test_index_on_save(self):
+        """Index a LearningObject upon creation."""
+        search_text = "The quick brown fox."
+        self.assertTrue(self.count_results(search_text) == 0)
+        self.resource.content_xml = search_text
+        self.resource.save()
+        self.assertTrue(self.count_results(search_text) == 1)
+
+    def test_index_vocabulary(self):
+        """
+        Test that LearningResource indexes are updated when a
+        a term is added or removed.
+        """
+        set_cache_timeout(0)
+        term = self.terms[0]
+        self.assertEqual(self.count_faceted_results(
+            self.vocabulary.name, term.label), 0)
+        self.resource.terms.add(term)
+        refresh_index()
+        self.assertEqual(self.count_faceted_results(
+            self.vocabulary.name, term.label), 1)
+        self.resource.terms.remove(term)
+        refresh_index()
+        self.assertEqual(self.count_faceted_results(
+            self.vocabulary.name, term.label), 0)
+
+    def test_strip_xml(self):
+        """Indexed content_xml should have XML stripped."""
+        xml = "<tag>you're it</tag>"
+        self.resource.content_xml = xml
+        self.resource.save()
+        refresh_index()
+        self.assertTrue(self.count_results("you're it") == 1)
+        self.assertTrue(self.count_results("tag") == 0)
+
+    def test_sorting(self):
+        """Test sorting for search"""
+        # remove the default resource to control the environment
+        self.resource.delete()
+        # create some resources
+        res1 = self.create_resource(**dict(
+            resource_type="example",
+            title="silly example 1",
+            content_xml="<blah>blah 1</blah>",
+            mpath="/blah1",
+            xa_nr_views=1001,
+            xa_nr_attempts=99,
+            xa_avg_grade=9.9
+        ))
+        res2 = self.create_resource(**dict(
+            resource_type="example",
+            title="silly example 2",
+            content_xml="<blah>blah 2</blah>",
+            mpath="/blah2",
+            xa_nr_views=1003,
+            xa_nr_attempts=98,
+            xa_avg_grade=6.8
+        ))
+        res3 = self.create_resource(**dict(
+            resource_type="example",
+            title="silly example 3",
+            content_xml="<blah>blah 3</blah>",
+            mpath="/blah3",
+            xa_nr_views=1002,
+            xa_nr_attempts=101,
+            xa_avg_grade=7.3
+        ))
+        res4 = self.create_resource(**dict(
+            resource_type="example",
+            title="silly example 4",
+            content_xml="<blah>blah 4</blah>",
+            mpath="/blah3",
+            xa_nr_views=1003,
+            xa_nr_attempts=101,
+            xa_avg_grade=9.9
+        ))
+        index_resources([res1, res2, res3, res4])
+        refresh_index()
+        self.assertEqual(self.count_results(), 4)
+        # sorting by number of views
+        results = self.search(
+            query=None,
+            sorting=LoreSortingFields.SORT_BY_NR_VIEWS[0]
+        )
+        # expected position res2, res4
+        top_res = results[0]
+        sec_res = results[1]
+        self.assertEqual(
+            top_res.id,
+            res2.id
+        )
+        self.assertEqual(
+            sec_res.id,
+            res4.id
+        )
+        # sorting by number of attempts
+        results = self.search(
+            query=None,
+            sorting=LoreSortingFields.SORT_BY_NR_ATTEMPTS[0]
+        )
+        # expected position res3, res4
+        top_res = results[0]
+        sec_res = results[1]
+        self.assertEqual(
+            top_res.id,
+            res3.id
+        )
+        self.assertEqual(
+            sec_res.id,
+            res4.id
+        )
+        # sorting by average grade
+        results = self.search(
+            query=None,
+            sorting=LoreSortingFields.SORT_BY_AVG_GRADE[0]
+        )
+        # expected position res1, res4
+        top_res = results[0]
+        sec_res = results[1]
+        self.assertEqual(
+            top_res.id,
+            res1.id
+        )
+        self.assertEqual(
+            sec_res.id,
+            res4.id
+        )

--- a/search/tests/test_indexing.py
+++ b/search/tests/test_indexing.py
@@ -205,11 +205,11 @@ class TestIndexing(SearchTestCase):
             return count
 
         set_cache_timeout(0)
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(26):
             self.assertEqual(get_count(), 0)
 
         set_cache_timeout(60)
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(12):
             self.assertEqual(get_count(), 1)
 
     def test_course_cache(self):

--- a/search/utils.py
+++ b/search/utils.py
@@ -1,0 +1,387 @@
+"""
+Search functions.
+"""
+
+from __future__ import unicode_literals
+
+from collections import defaultdict
+from lxml import etree
+import logging
+
+from django.conf import settings
+from elasticsearch.helpers import bulk
+from elasticsearch.exceptions import NotFoundError
+from elasticsearch_dsl.connections import connections
+from elasticsearch_dsl import Search, Mapping, query
+
+from statsd.defaults.django import statsd
+
+from learningresources.models import get_preview_url, LearningResource
+from search.search_indexes import get_course_metadata
+
+log = logging.getLogger(__name__)
+
+DOC_TYPE = "learningresource"
+INDEX_NAME = settings.HAYSTACK_CONNECTIONS["default"]["INDEX_NAME"]
+URL = settings.HAYSTACK_CONNECTIONS["default"]["URL"]
+_CONN = None
+PAGE_LENGTH = 10
+
+
+def get_conn():
+    """
+    Lazily create the connection.
+    """
+    # pylint: disable=global-statement
+    # This is ugly. Any suggestions on a way that doesn't require "global"?
+    global _CONN
+    if _CONN is None:
+        _CONN = connections.create_connection(hosts=[URL])
+    return _CONN
+
+
+def get_resource_terms(resource_ids):
+    """
+    Returns taxonomy metadata for LearningResources.
+    Args:
+        resource_ids (iterable of int): Primary keys of LearningResources
+    Returns:
+        data (dict): Vocab/term data for course.
+    """
+    resource_data = defaultdict(lambda: defaultdict(list))
+    rels = LearningResource.terms.related.through.objects.select_related(
+        "term__vocabulary").filter(learningresource__id__in=resource_ids)
+    for rel in rels.iterator():
+        obj = resource_data[rel.learningresource_id]
+        obj[rel.term.vocabulary.name].append(rel.term.label)
+    # Replace the defaultdicts with dicts.
+    return {k: dict(v) for k, v in resource_data.items()}
+
+
+def search_index(tokens=None, repo_slug=None, sort_by=None, terms=None):
+    """
+    Perform a search in Elasticsearch.
+
+    Args:
+        tokens (unicode): string of one or more words
+        repo_slug (unicode): repository slug
+        sort_by (string): field to sort by
+        terms: (dict): {"vocabulary name": ["term1" [, "term2"]]}
+    Returns:
+        results (SearchResults)
+    """
+    if terms is None:
+        terms = {}
+    if tokens is None:
+        # Retrieve everything.
+        search = Search(index=INDEX_NAME, doc_type=DOC_TYPE).query()
+    else:
+        # Search on title, description, and content_xml (minus markup).
+        search = Search(index=INDEX_NAME, doc_type=DOC_TYPE)
+        multi = query.MultiMatch(
+            query=tokens, fields=["title", "description", "content_stripped"])
+        search = search.query(multi)
+    if terms != {}:
+        # Filter further on taxonomy terms.
+        search = search.query("match", **terms)
+    if repo_slug is not None:
+        # Filter further on repository.
+        search = search.query("match", repository=repo_slug)
+    if sort_by is not None:
+        # Temporary workaround; the values in sorting.py should be updated,
+        # but for now Haystack is still using them. Also, the hyphen is
+        # required because we sort the numeric values high to low.
+        if not sort_by.startswith("title"):
+            sort_by = "-xa_{0}".format(sort_by)
+        search = search.sort(sort_by, "id")
+    return SearchResults(search)
+
+
+@statsd.timer('lore.elasticsearch.bulk_index')
+def index_resources(resources):
+    """Add/update records in Elasticsearch."""
+
+    if hasattr(resources, "values_list"):
+        # If it's a queryset, get the IDs the smart way.
+        resource_ids = resources.values_list("id", flat=True)
+    else:
+        resource_ids = [x.id for x in resources]
+    # Terms assigned to the resources.
+    term_info = get_resource_terms(resource_ids)
+
+    if hasattr(resources, "iterator"):
+        # If it's a queryset, be efficient.
+        resources = resources.iterator()
+
+    ensure_vocabulary_mappings(term_info)
+
+    # Perform bulk insert using Elasticsearch directly.
+    conn = get_conn()
+    insert_count, errors = bulk(
+        conn,
+        (resource_to_dict(x, term_info.get(x.id, {})) for x in resources),
+        index=INDEX_NAME,
+        doc_type=DOC_TYPE
+    )
+
+    if errors != []:
+        log.error("Error during bulk insert: %s", errors)
+
+    return insert_count
+
+
+@statsd.timer('lore.elasticsearch.delete_index')
+def delete_index(resource):
+    """Delete a record from Elasticsearch."""
+    conn = get_conn()
+    try:
+        conn.delete(
+            index=INDEX_NAME, doc_type=DOC_TYPE, id=resource.id)
+        refresh_index()
+    except NotFoundError:
+        # We tried to delete something that wasn't in the index.
+        # In that case, we don't care; the desired outcome is identical.
+        pass
+
+
+def resource_to_dict(resource, term_info=None):
+    """
+    Retrieve important values from a LearningResource to index.
+
+    This dict corresponds to the mapping created in Elasticsearch.
+
+    The titlesort bits, with the "0" and "1" prefixes, were copied from
+    the prepare_titlesort function in search/search_indexes.py. It was there
+    to make blank titles sort to the bottom instead of the top.
+
+    Args:
+        resource (LearningResource): Item to convert to dict.
+        term_info (dict): Vocabulary terms assigned to resource.
+    Returns:
+        rec (dict): Dictionary representation of the LearningResource.
+    """
+
+    if term_info is None:
+        term_info = {}
+    rec = {
+        "title": resource.title,
+        # The zero is for sorting blank items to the bottom. See below.
+        "titlesort": "0{0}".format(resource.title.strip()),
+        "id": resource.id,
+        "_id": resource.id,  # The ID used by Elasticsearch.
+        "resource_type": resource.learning_resource_type.name,
+        "description": resource.description,
+        "content_xml": resource.content_xml,
+        "content_stripped": strip_xml(resource.content_xml),
+        "xa_nr_views": resource.xa_nr_views,
+        "xa_nr_attempts": resource.xa_nr_attempts,
+        "xa_avg_grade": resource.xa_avg_grade,
+        "xa_histogram_grade": resource.xa_histogram_grade,
+    }
+
+    course = get_course_metadata(resource.course_id)
+    rec["preview_url"] = get_preview_url(
+        resource,
+        org=course["org"],
+        course_number=course["course_number"],
+        run=course["run"],
+    )
+    rec["run"] = course["run"]
+    rec["course"] = course["course_number"]
+    rec["repository"] = course["repo_slug"]
+
+    # Index term info. Since these fields all use the "not_analyzed"
+    # index, they must all be exact matches.
+    for key, vals in term_info.items():
+        rec[key] = vals
+
+    # If the title is empty, sort it to the bottom. See above.
+    if rec["titlesort"] == "0":
+        rec["titlesort"] = "1"
+
+    # Keys that may have unicode issues.
+    text_keys = (
+        'title', 'titlesort', 'resource_type', 'description', 'content_xml',
+        'content_stripped',
+    )
+    for key in text_keys:
+        try:
+            # Thanks to unicode_literals above, this works in
+            # Python 2 and Python 3. Avoid trying to decode a string
+            # if it's already unicode.
+            if not isinstance(rec[key], type("")):
+                rec[key] = rec[key].decode('utf-8')
+        except AttributeError:
+            pass  # Python 3
+    return rec
+
+
+def clear_index():
+    """Wipe the index."""
+    conn = get_conn()
+    if conn.indices.exists(INDEX_NAME):
+        conn.indices.delete(INDEX_NAME)
+        conn.indices.create(INDEX_NAME)
+        conn.indices.refresh()
+    create_mapping()
+
+    # re-index all existing LearningResource instances:
+    index_resources(LearningResource.objects.all())
+
+
+class SearchResults(object):
+    """
+    Helper class for elasticsearch_dsl search results.
+
+    This is because the actual search result has nested types, which
+    would be cumbersome to access from arbitrary calling functions.
+    """
+    def __init__(self, search):
+        """Get raw search result from Elasticsearch."""
+        self._search = search
+
+    def count(self):
+        """Total records matching the query."""
+        return self._search.count()
+
+    def page_count(self):
+        """Total number of result pages."""
+        total = self._search.count()
+        count = total / PAGE_LENGTH
+        if total % PAGE_LENGTH > 0:
+            count += 1
+        return int(count)
+
+    def get_page(self, page):
+        """Return paginated results."""
+        start = (page - 1) * PAGE_LENGTH
+        end = start + PAGE_LENGTH
+        return self._search[start:end].execute().hits
+
+    def all(self):
+        """Return all results in a generator."""
+        for i in range(self.page_count()):
+            for hit in self.get_page(i+1):
+                yield hit
+
+    def __getitem__(self, i):
+        """Return result by index."""
+        return self._search[i].execute().hits[0]
+
+
+def create_mapping():
+    """
+    Create the Elasticsearch mapping.
+
+    Notes on the "index" values:
+        analyzed: normal, will be split on whitespace for indexing
+            (partial matches can be made during queries)
+        not_analyzed: no split; matches must be exact
+        no: not indexed at all, but will be returned in search results
+    """
+
+    # Create the index if it doesn't exist.
+    conn = get_conn()
+    if not conn.indices.exists(INDEX_NAME):
+        conn.indices.create(INDEX_NAME)
+    # Delete the mapping if an older version exists.
+    if conn.indices.exists_type(index=INDEX_NAME, doc_type=DOC_TYPE):
+        conn.indices.delete_mapping(index=INDEX_NAME, doc_type=DOC_TYPE)
+
+    mapping = Mapping(DOC_TYPE)
+
+    mapping.field("course", "string", index="not_analyzed")
+    mapping.field("description_path", "string", index="no")
+    mapping.field("description", "string", index="analyzed")
+    mapping.field("preview_url", "string", index="no")
+    mapping.field("repository", "string", index="not_analyzed")
+    mapping.field("resource_type", "string", index="not_analyzed")
+    mapping.field("content_xml", "string", index="no")
+    mapping.field("content_stripped", "string", index="analyzed")
+    mapping.field("run", "string", index="not_analyzed")
+    mapping.field("titlesort", "string", index="no")
+    mapping.field("title", "string", index="analyzed")
+
+    mapping.field("xa_avg_grade", "float")
+    mapping.field("xa_histogram_grade", "float")
+    mapping.field("xa_nr_attempts", "integer")
+    mapping.field("xa_nr_views", "integer")
+
+    mapping.save(INDEX_NAME)
+
+    # If we've done this, we always want to re-index all existing
+    # LearningResource instances. This function will probably only
+    # ever be called by migrations.
+    index_resources(LearningResource.objects.all())
+    conn.indices.refresh()
+
+
+def refresh_index():
+    """
+    Force a refresh instead of waiting for it to happen automatically.
+    This should only be necessary during tests.
+    """
+    conn = get_conn()
+    conn.indices.refresh(index=INDEX_NAME)
+
+
+def ensure_vocabulary_mappings(term_info):
+    """
+    Ensure the mapping is properly set in Elasticsearch to always do exact
+    matches on taxonomy terms. Accepts the output of get_resource_terms.
+
+    Calling this function during indexing means that vocabularies do not
+    need to be added to the mapping in advance. This deals with the fact
+    that vocabularies can be added on-the-fly without having to play around
+    with extra signals.
+
+    Args:
+        term_info (dict): Details of terms for a group of LearningResources.
+    """
+    if len(term_info) == 0:
+        return
+
+    # Retrieve current mapping from Elasticsearch.
+    mapping = Mapping.from_es(index=INDEX_NAME, doc_type=DOC_TYPE)
+
+    # Get the field names from the mapping.
+    existing_vocabs = set(mapping.to_dict()["learningresource"]["properties"])
+
+    # Get all the taxonomy names from the data.
+    vocab_names = set()
+    for result in term_info.values():
+        for key in result.keys():
+            vocab_names.add(key)
+    updated = False
+    # Add vocabulary to mapping if necessary.
+    for name in vocab_names:
+        if name in existing_vocabs:
+            continue
+        mapping.field(name, "string", index="not_analyzed", null_value="empty")
+        updated = True
+    if updated:
+        mapping.save(INDEX_NAME)
+
+
+def strip_xml(content):
+    """
+    Strip XML from a string.
+    Args:
+        content (unicode): some XML
+    Returns:
+        output (unicode): plain text
+    """
+    try:
+        # Strip XML tags from content before indexing.
+        tree = etree.fromstring(content)
+        content = etree.tostring(tree, encoding="utf-8", method="text")
+    except etree.XMLSyntaxError:
+        # For blank/invalid XML.
+        pass
+    try:
+        content = content.decode('utf-8')
+    except AttributeError:
+        # For Python 3.
+        pass
+
+    return content


### PR DESCRIPTION
Haystack will removed once all the features are added and tested. This requires
the addition of searching by facets, React.js updates, and updates to the
restful API.

Before code review, please watch [this](https://youtu.be/uU66q-8Zofg), which explains how the new libraries are being used.

The `search/utils.py` file should be read first, in this order:
-  `create_mapping`
- `resource_to_dict`
- `index_resources`
- `search_index`
- `class SearchResults`
- the rest

This should make the tests easy to follow.
