### PR TITLE
Switched django local storage to overwrite

### DIFF
--- a/learningresources/tests/test_models.py
+++ b/learningresources/tests/test_models.py
@@ -145,7 +145,7 @@ class TestModels(LoreTestCase):
                 FILE_PATH_MAX_LENGTH -
                 # minus the length of the base path of the Django storage and
                 # the base path of the file location temporary dir
-                len(os.path.join(base_path, temp_dir_path)) -
+                len('/'.join([base_path, temp_dir_path])) -
                 # minus 1 for the extra "/" to joint the paths
                 1
             )

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -237,7 +237,9 @@ if(
 if LORE_USE_S3:
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 else:
-    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+    # by default use django.core.files.storage.FileSystemStorage with
+    # overwrite feature
+    DEFAULT_FILE_STORAGE = 'storages.backends.overwrite.OverwriteStorage'
 
 
 # Lore preview settings

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,50 @@
+"""
+Tests for django storage
+"""
+from __future__ import unicode_literals
+
+import os
+from shutil import rmtree
+from tempfile import mkdtemp
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.test.testcases import TestCase
+
+
+class TestStorage(TestCase):
+    """
+    Tests for Django storage
+    """
+
+    def test_local_storage(self):
+        """
+        Tests for local storage
+        It has to be OverwriteStorage to avoid problems with static assets
+        having the same name
+        """
+
+        # default setting
+        self.assertEqual(
+            settings.DEFAULT_FILE_STORAGE,
+            'storages.backends.overwrite.OverwriteStorage'
+        )
+
+        temp_dir_path = mkdtemp()
+        self.addCleanup(rmtree, temp_dir_path)
+
+        path = os.path.join(temp_dir_path, 'temp_file.txt')
+
+        # create the first file
+        default_storage.save(path, ContentFile('nonsense content'))
+        # create another with the same name
+        content = 'nonsense content 2'
+        default_storage.save(path, ContentFile(content))
+
+        # there is only one file in the directory
+        self.assertEqual(len(os.listdir(temp_dir_path)), 1)
+
+        with open(path) as fhand:
+            content_read = fhand.read()
+        self.assertEqual(content, content_read)

--- a/ui/tests/test_learningresources_views.py
+++ b/ui/tests/test_learningresources_views.py
@@ -293,7 +293,7 @@ class TestViews(LoreTestCase):
         """Hit serve media"""
         self.assertEqual(
             settings.DEFAULT_FILE_STORAGE,
-            'django.core.files.storage.FileSystemStorage'
+            'storages.backends.overwrite.OverwriteStorage'
         )
         # upload a course
         self.upload_test_file()


### PR DESCRIPTION
The default django local storage does not allow to overwrite files with
the same name and this is a problem for our static assets.
