### PR TITLE
Wrapped description text to 2 lines and added expand collapse description functionality

### DIFF
--- a/ui/jstests/test_listing_resources.jsx
+++ b/ui/jstests/test_listing_resources.jsx
@@ -8,6 +8,8 @@ define(['QUnit', 'jquery', 'listing_resources', 'react',
     var Listing = ListingResources.Listing;
     var ListingResource = ListingResources.ListingResource;
     var SortingDropdown = ListingResources.SortingDropdown;
+    var DescriptionListingResource = ListingResources.
+      DescriptionListingResource;
     var loader = ListingResources.loader;
     var getImageFile = ListingResources.getImageFile;
 
@@ -258,9 +260,6 @@ define(['QUnit', 'jquery', 'listing_resources', 'react',
         };
 
         var afterMount = function(component) {
-          // ListingResource has no state
-          assert.equal(null, component.state);
-
           // Assert link behavior
           var node = React.findDOMNode(component);
           assert.deepEqual(openResourcePanelCount, {});
@@ -318,6 +317,268 @@ define(['QUnit', 'jquery', 'listing_resources', 'react',
             repoSlug={listingOptions.repoSlug}
             openResourcePanel={openResourcePanel}
             updateExportLinkClick={updateExportLinkClick}
+            ref={afterMount}
+            />
+        );
+      }
+    );
+
+    /*
+     Listing resource description tests
+     */
+    QUnit.test('Assert description expands and collapse' +
+      ' in ListingResource',
+      function(assert) {
+        var done = assert.async();
+
+        var resource = {
+          "run": "2015_Summer",
+          "description": "Lorem Ipsum is simply dummy text of the printing" +
+          "  and typesetting industry. Lorem Ipsum has been the industry's " +
+          " standard dummy text ever since the 1500s, when an unknown " +
+          " took a galley of type and scrambled it to make a type specimen" +
+          " book. It has survived not only five centuries, but also the" +
+          " leap into electronic typesetting, remaining essentially" +
+          " unchanged. It was popularised in the 1960s with the release " +
+          " of Letraset sheets containing Lorem Ipsum passages, and more " +
+          " recently with desktop publishing software like Aldus PageMaker" +
+          " including versions of",
+          "course": "0.001",
+          "xa_avg_grade": 68.0,
+          "lid": 23,
+          "title": "Circuit Schematic Builder",
+          "description_path": "Ops / Content/problem tests / Sample problems" +
+          " / Circuit schematic builder / Circuit Schematic Builder",
+          "xa_nr_views": 9755,
+          "preview_url": "https://www.sandbox.edx.org/courses/DevOps/0.001/" +
+          "2015_Summer/jump_to_id/71101093d5234c8a87488ed9a27db531",
+          "xa_nr_attempts": 717,
+          "resource_type": "problem"
+        };
+        var openResourcePanel = function() {};
+        var updateExportLinkClick = function() {};
+
+        var afterMount = function(component) {
+          // Assert link behavior
+          var node = React.findDOMNode(component);
+
+          // Description
+          var descriptionDiv = $(node).find(".tile-blurb")[0];
+          var text = $(descriptionDiv).text();
+          assert.equal(text.length, 122);
+
+          var expandLink = $(descriptionDiv).find('a')[0];
+          assert.ok(expandLink, "Expand link exist"); // assert link exist
+
+          // Test description expands on ReadMore link click
+          React.addons.TestUtils.Simulate.click(expandLink);
+          component.forceUpdate(function() {
+            assert.equal(component.state.showDescInDetail, true);
+            node = React.findDOMNode(component);
+            descriptionDiv = $(node).find(".tile-blurb")[0];
+            text = $(descriptionDiv).text();
+
+            assert.ok(text.length > 120, "Description size is greater the 120");
+            var collapseLink = $(descriptionDiv).find('a')[0];
+            assert.ok(collapseLink, "Collapse link exist"); // assert link exist
+            React.addons.TestUtils.Simulate.click(collapseLink);
+            // Test description collapse on ReadLess link click
+            component.forceUpdate(function() {
+              assert.equal(component.state.showDescInDetail, false);
+              node = React.findDOMNode(component);
+              descriptionDiv = $(node).find(".tile-blurb")[0];
+              text = $(descriptionDiv).text();
+              assert.equal(text.length, 122);
+              done();
+            });
+          });
+        };
+
+        React.addons.TestUtils.renderIntoDocument(
+          <ListingResource
+            resource={resource}
+            exportSelected={_.includes(listingOptions.allExports, resource.lid)}
+            imageDir={listingOptions.imageDir}
+            repoSlug={listingOptions.repoSlug}
+            openResourcePanel={openResourcePanel}
+            updateExportLinkClick={updateExportLinkClick}
+            ref={afterMount}
+            />
+        );
+      }
+    );
+
+    QUnit.test('Assert description expands in ListingResource',
+      function(assert) {
+        var done = assert.async();
+        var showDetail;
+
+        var showDescInDetailHandler = function(showDetailFlag) {
+          showDetail = showDetailFlag;
+        };
+
+        var resource = {
+          "run": "2015_Summer",
+          "description": "Lorem Ipsum is simply dummy text of the printing" +
+          "  and typesetting industry. Lorem Ipsum has been the industry's " +
+          " standard dummy text ever since the 1500s, when an unknown " +
+          " took a galley of type and scrambled it to make a type specimen" +
+          " book. It has survived not only five centuries, but also the" +
+          " leap into electronic typesetting, remaining essentially" +
+          " unchanged. It was popularised in the 1960s with the release " +
+          " of Letraset sheets containing Lorem Ipsum passages, and more " +
+          " recently with desktop publishing software like Aldus PageMaker" +
+          " including versions of",
+          "course": "0.001",
+          "xa_avg_grade": 68.0,
+          "lid": 23,
+          "title": "Circuit Schematic Builder",
+          "description_path": "Ops / Content/problem tests / Sample problems" +
+          " / Circuit schematic builder / Circuit Schematic Builder",
+          "xa_nr_views": 9755,
+          "preview_url": "https://www.sandbox.edx.org/courses/DevOps/0.001/" +
+          "2015_Summer/jump_to_id/71101093d5234c8a87488ed9a27db531",
+          "xa_nr_attempts": 717,
+          "resource_type": "problem"
+        };
+
+        var afterMount = function(component) {
+          // Assert link behavior
+          var descriptionDiv = React.findDOMNode(component);
+          var text = $(descriptionDiv).text();
+          assert.equal(text.length, 122);
+
+          var expandLink = $(descriptionDiv).find('a')[0];
+          assert.ok(expandLink, "Expand link exist"); // assert link exist
+
+          React.addons.TestUtils.Simulate.click(expandLink);
+          component.forceUpdate(function() {
+            assert.equal(showDetail,  true, "Description is expanded");
+            done();
+          });
+        };
+
+        React.addons.TestUtils.renderIntoDocument(
+          <DescriptionListingResource
+            resource={resource}
+            showDetail={false}
+            showDescInDetailHandler={showDescInDetailHandler}
+            ref={afterMount}
+            />
+        );
+      }
+    );
+
+    QUnit.test('Assert description collapse in ListingResource',
+      function(assert) {
+        var done = assert.async();
+        var showDetail;
+
+        var showDescInDetailHandler = function(showDetailFlag) {
+          showDetail = showDetailFlag;
+        };
+
+        var resource = {
+          "run": "2015_Summer",
+          "description": "Lorem Ipsum is simply dummy text of the printing" +
+          "  and typesetting industry. Lorem Ipsum has been the industry's " +
+          " standard dummy text ever since the 1500s, when an unknown " +
+          " took a galley of type and scrambled it to make a type specimen" +
+          " book. It has survived not only five centuries, but also the" +
+          " leap into electronic typesetting, remaining essentially" +
+          " unchanged. It was popularised in the 1960s with the release " +
+          " of Letraset sheets containing Lorem Ipsum passages, and more " +
+          " recently with desktop publishing software like Aldus PageMaker" +
+          " including versions of",
+          "course": "0.001",
+          "xa_avg_grade": 68.0,
+          "lid": 23,
+          "title": "Circuit Schematic Builder",
+          "description_path": "Ops / Content/problem tests / Sample problems" +
+          " / Circuit schematic builder / Circuit Schematic Builder",
+          "xa_nr_views": 9755,
+          "preview_url": "https://www.sandbox.edx.org/courses/DevOps/0.001/" +
+          "2015_Summer/jump_to_id/71101093d5234c8a87488ed9a27db531",
+          "xa_nr_attempts": 717,
+          "resource_type": "problem"
+        };
+
+        var afterMount = function(component) {
+          // Assert link behavior
+          var descriptionDiv = React.findDOMNode(component);
+          var text = $(descriptionDiv).text();
+          assert.ok(text.length > 120, "Description size is greater the 120");
+
+          var collapseLink = $(descriptionDiv).find('a')[0];
+          assert.ok(collapseLink, "Collapse link exist"); // assert link exist
+          React.addons.TestUtils.Simulate.click(collapseLink);
+          component.forceUpdate(function() {
+            assert.equal(showDetail,  false, "Description is collapsed");
+            done();
+          });
+        };
+
+        React.addons.TestUtils.renderIntoDocument(
+          <DescriptionListingResource
+            resource={resource}
+            showDetail={true}
+            showDescInDetailHandler={showDescInDetailHandler}
+            ref={afterMount}
+            />
+        );
+      }
+    );
+
+    QUnit.test('Assert description collapse in ListingResource' +
+      '(continue characters description)',
+      function(assert) {
+        var done = assert.async();
+        var showDetail;
+
+        var showDescInDetailHandler = function(showDetailFlag) {
+          showDetail = showDetailFlag;
+        };
+
+        var resource = {
+          "run": "2015_Summer",
+          "description": "LoremIpsumissimplydummytextoftheprinting" +
+          "andtypesettingindustry.LoremIpsumhasbeentheindustry's " +
+          "standarddummytexteversincethe1500s,whenanunknown" +
+          "tookagalleyoftypeandscrambledittomakeatypespecimen" +
+          "includingversionsof",
+          "course": "0.001",
+          "xa_avg_grade": 68.0,
+          "lid": 23,
+          "title": "Circuit Schematic Builder",
+          "description_path": "Ops / Content/problem tests / Sample problems" +
+          " / Circuit schematic builder / Circuit Schematic Builder",
+          "xa_nr_views": 9755,
+          "preview_url": "https://www.sandbox.edx.org/courses/DevOps/0.001/" +
+          "2015_Summer/jump_to_id/71101093d5234c8a87488ed9a27db531",
+          "xa_nr_attempts": 717,
+          "resource_type": "problem"
+        };
+
+        var afterMount = function(component) {
+          // Assert link behavior
+          var descriptionDiv = React.findDOMNode(component);
+          var text = $(descriptionDiv).text();
+          assert.ok(text.length > 120, "Description size is greater the 120");
+
+          var collapseLink = $(descriptionDiv).find('a')[0];
+          assert.ok(collapseLink, "Collapse link exist"); // assert link exist
+          React.addons.TestUtils.Simulate.click(collapseLink);
+          component.forceUpdate(function() {
+            assert.equal(showDetail,  false, "Description is collapsed");
+            done();
+          });
+        };
+
+        React.addons.TestUtils.renderIntoDocument(
+          <DescriptionListingResource
+            resource={resource}
+            showDetail={true}
+            showDescInDetailHandler={showDescInDetailHandler}
             ref={afterMount}
             />
         );

--- a/ui/static/ui/css/mit-lore.css
+++ b/ui/static/ui/css/mit-lore.css
@@ -264,6 +264,12 @@ a {
     font-size: 12px;
 }
 
+.link-description-more-less {
+    margin: 0;
+    display: inline-block;
+    font-size: 12px;
+}
+
 .tile-content {
     width: 75%;
     display: inline-block;

--- a/ui/static/ui/js/listing_resources.jsx
+++ b/ui/static/ui/js/listing_resources.jsx
@@ -239,7 +239,66 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
       }
     });
 
+    var DescriptionListingResource = React.createClass({
+      render: function() {
+        if (this.props.showDetail) {
+          return <div className="tile-blurb">{this.expandDescription()}</div>;
+        }
+
+        return <div className="tile-blurb">{this.wrapDescription()}</div>;
+      },
+      wrapDescription: function() {
+        var resource = this.props.resource;
+        var description = "No description provided.";
+        if (resource.description !== "") {
+          if (resource.description.length > 120) {
+            var wrapDesc ;
+            var positionOfSpace = resource.description.indexOf(" ",  110);
+
+            if (positionOfSpace > 0) {
+              wrapDesc = resource.description.substring(0, positionOfSpace);
+            } else {
+              wrapDesc = resource.description.substring(0, 120);
+            }
+
+            description = <span>
+              {wrapDesc} <a onClick={this.expandLinkClick} href="#"
+              className="link-description-more-less">
+               Read more <i className="fa fa-chevron-down"></i>
+              </a>
+            </span>;
+          } else {
+            description = resource.description;
+          }
+        }
+        return description;
+      },
+      expandDescription: function() {
+        var resource = this.props.resource;
+        var expandDesc = <span>
+          {resource.description} <a onClick={this.collapseLinkClick} href="#"
+           className="link-description-more-less">
+           Read less <i className="fa fa-chevron-up"></i>
+          </a>
+        </span>;
+        return expandDesc;
+      },
+      collapseLinkClick: function(event) {
+        event.preventDefault();
+        this.props.showDescInDetailHandler(false);
+      },
+      expandLinkClick: function(event) {
+        event.preventDefault();
+        this.props.showDescInDetailHandler(true);
+      }
+    });
+
     var ListingResource = React.createClass({
+      getInitialState: function() {
+        return {
+          showDescInDetail: false
+        };
+      },
       render: function() {
         // Select image based on type.
         var resource = this.props.resource;
@@ -250,11 +309,6 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
         var title = "No Title";
         if (resource.title !== "") {
           title = resource.title;
-        }
-
-        var description = "No description provided.";
-        if (resource.description !== "") {
-          description = resource.description;
         }
 
         return <div className="row">
@@ -274,7 +328,10 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
                   <span className="meta-item">{resource.description_path}</span>
                 </div>
 
-                <div className="tile-blurb">{description}</div>
+                <DescriptionListingResource resource={this.props.resource}
+                   showDetail={this.state.showDescInDetail}
+                   showDescInDetailHandler={this.showDescInDetailHandler}
+                />
                 <div className="tile-meta">
                   <span className="meta-item">{resource.course}</span>
                   <span className="meta-item">{resource.run}</span>
@@ -313,6 +370,9 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
       handleResourceClick: function(e) {
         e.preventDefault();
         this.props.openResourcePanel(this.props.resource.id);
+      },
+      showDescInDetailHandler: function(showDescInDetail) {
+        this.setState({showDescInDetail: showDescInDetail});
       }
     });
 
@@ -468,6 +528,7 @@ define('listing_resources', ['react', 'jquery', 'lodash', 'utils'],
         );
       },
       getImageFile: getImageFile,
+      DescriptionListingResource: DescriptionListingResource,
       ExportButton: ExportButton,
       ExportLink: ExportLink,
       SortingDropdown: SortingDropdown,


### PR DESCRIPTION
Hi 

In this PR I made less description text by wrapping it. Now we have expand and collapse link with text as well.

Issue: https://github.com/mitodl/lore/issues/599
@pdpinch @noisecapella 

![screen shot 2015-09-21 at 6 52 42 pm](https://cloud.githubusercontent.com/assets/10431250/9993580/ff2458aa-6091-11e5-862a-267d5a0bc08f.png)
![screen shot 2015-09-21 at 6 52 47 pm](https://cloud.githubusercontent.com/assets/10431250/9993579/ff206de4-6091-11e5-9a9c-c11c7592f5ed.png)
