### PR TITLE
Release 0.11.0

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,12 +1,35 @@
 Release Notes
 -------------
 
+Version 0.11.0
+==============
+
+- Reorganized Learning Resource panel to use three tabs.
+- Added datatable proof-of-concept.
+- Added REST api view to get and delete a course.
+- Added calls to ``get_conn()`` where ``conn`` is used implicitly.
+- Added more detail to confirmation message for delete vocabulary.
+- Moved ``Save`` button to right of the term for edit term inside
+  taxonomy panel.
+- Switched Django local storage to overwrite.
+- Implemented ``page_size`` parameter to allow users to set page size.
+- Fixed spacing between ``edit`` and ``delete`` buttons.
+- Removed /node directory, and removed symlinks from node_modules.
+- Added elasticsearch-dsl and added it alongside Haystack for now.
+- Added ``Save and Close`` button to learning resource panel.
+- Added tests for listing page.
+- Removed lib/ from ``.gitignore``.
+- Switched to minimized javascript for libraries.
+- Added REST API view to list courses in repository.
+- Removed react-addons bower package, addons actually live in react package.
+- Fixed pagination links.
+- Increased requirejs timeout.
+
 Version 0.10.1
 ==============
 
 - Fixed exact repository search bug
 - Fixed clear export bug
-
 
 Version 0.10.0
 ==============

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,8 +31,8 @@ master_doc = 'index'
 project = u'LORE'
 copyright = u'2015, MIT Office of Digital Learning'
 
-version = '0.1'
-release = '0.1.0'
+version = '0.11.0'
+release = '0.11.0'
 
 exclude_patterns = ['_build']
 pygments_style = 'sphinx'

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -15,7 +15,7 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 import yaml
 
-VERSION = '0.10.1'
+VERSION = '0.11.0'
 
 CONFIG_PATHS = [
     os.environ.get('LORE_CONFIG', ''),


### PR DESCRIPTION
Release 0.11.0
- Reorganized Learning Resource panel to use three tabs.
- Added datatable proof-of-concept.
- Added REST api view to get and delete a course.
- Added calls to `get_conn()` where `conn` is used implicitly.
- Added more detail to confirmation message for delete vocabulary.
- Moved `Save` button to right of the term for edit term inside
  taxonomy panel.
- Switched Django local storage to overwrite.
- Implemented `page_size` parameter to allow users to set page size.
- Fixed spacing between `edit` and `delete` buttons.
- Removed /node directory, and removed symlinks from node_modules.
- Added elasticsearch-dsl and added it alongside Haystack for now.
- Added `Save and Close` button to learning resource panel.
- Added tests for listing page.
- Removed lib/ from `.gitignore`.
- Switched to minimized javascript for libraries.
- Added REST API view to list courses in repository.
- Removed react-addons bower package, addons actually live in react package.
- Fixed pagination links.
- Increased requirejs timeout.
