### PR TITLE
Pinned PyTest to a version < 2.8

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 # Core project/common application testing requirements
 
-pytest
+pytest<2.8
 pytest-pep8
 pytest-pylint
 pytest-cov


### PR DESCRIPTION
pytest-capturelog has problems with the latest version and
raises warnings
