### PR TITLE
Configured newrelic python agent

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: uwsgi uwsgi.ini
+web: newrelic-admin run-program uwsgi uwsgi.ini
 worker: celery -A lore worker

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,6 @@ django-storages-redux==1.3
 python-magic==0.4.6
 boto>=2.38.0,<3.0.0
 beautifulsoup4==4.4.0
+
+# Application monitoring requirements
+newrelic==2.54.0.41


### PR DESCRIPTION
As we talked about it a little bit in our sprint retrospective, I've configured `lore-ci` to use the free newrelic service so we can try it out. For the free service, there is no dyno/time limit, but transactions aren't measured: https://addons.heroku.com/newrelic#wayne

It's easy to switch to a paid plan in the future if we needed, though.
