### PR TITLE
Fixed newrelic not reporting

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -7,3 +7,5 @@ wsgi-file = lore/wsgi.py
 memory-report = true
 pidfile=/tmp/lore-mast.pid
 vacuum=True
+enable-threads = true
+single-interpreter = true


### PR DESCRIPTION
The newrelic agent is running, but it's not reporting because it's unable to create background threads to perform monitoring tasks. Uwsgi disables threading in python interpreters by default.

For more info, see the "Mandatory options" section of: https://docs.newrelic.com/docs/agents/python-agent/hosting-mechanisms/python-agent-uwsgi

@pdpinch 
