### PR TITLE
Added limit to memory for Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ stats:
     - "8071:80"
 web:
   build: .
+  mem_limit: 384m
   command: >
     /bin/bash -c '
     export HOST_IP=$(netstat -nr | grep ^0\.0\.0\.0 | awk "{print \$2}") &&
@@ -53,6 +54,7 @@ web:
     - stats
 celery:
   image: lore_web
+  mem_limit: 384m
   command: >
     /bin/bash -c '
     sleep 3;


### PR DESCRIPTION
Having memory limits enforced in our development Docker containers may help catch errors. Note that these limits aren't enforced by default. I needed to set this line in `/etc/default/grub` for Ubuntu 15.04:

```
GRUB_CMDLINE_LINUX_DEFAULT="quiet splash cgroup_enable=memory swapaccount=1"
```

This causes a 10% performance hit according to Docker. I'm not sure how boot2docker is configured by default.
