### PR TITLE
Release 0.12.0

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,43 @@
 Release Notes
 -------------
 
+Version 0.12.0
+==============
+
+- Added task to index resources via Celery.
+- Wrapped course imports in transaction.
+- Limited vocabularies to repository being searched.
+- Updated Django to 1.8.5 due to a bugfix release.
+- Removed Haystack.
+- Moved Pagination inside Listing React component.
+- Fixed reindexing for edited vocabularies.
+- Updated status tests to use settings context.
+- Added limit to memory for Docker.
+- Added loader to listing, resource panel and taxonomy panel.
+- Chunked bulk indexing to lower memory footprint.
+- Fixed resource ids.
+- Added debug_toolbar.
+- Fixed mouse pointer on edit and delete links.
+- Fixed memory usage in migration.
+- Fixed collapse behavior.
+- Fixed NewRelic not reporting.
+- Added bulk insert of static assets during import.
+- Changed ``get_or_create`` to ``create``.
+- Replaced Haystack queryset and facet counts with elasticsearch-dsl.
+- Fixed ``id`` attribute for vocab and term select.
+- Added filtering on vocabulary and learning resource type for learning
+  resources.
+- Configured NewRelic Python agent.
+- Implemented verification of resource types on models.
+- Static assets are served again using local storage.
+- Fixed missing test module.
+- Replaced default missing title and updated description path.
+- Pinned PyTest to a version < 2.8.
+- Wrapped description text to 2 lines and added expand collapse description
+  functionality.
+- Added vocabulary editing in the taxonomy panel.
+- Added documentation for LORE release workflow.
+
 Version 0.11.0
 ==============
 

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -15,7 +15,7 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 import yaml
 
-VERSION = '0.11.0'
+VERSION = '0.12.0'
 
 CONFIG_PATHS = [
     os.environ.get('LORE_CONFIG', ''),


### PR DESCRIPTION
- Added task to index resources via Celery.
- Wrapped course imports in transaction.
- Limited vocabularies to repository being searched.
- Updated Django to 1.8.5 due to a bugfix release.
- Removed Haystack.
- Moved Pagination inside Listing React component.
- Fixed reindexing for edited vocabularies.
- Updated status tests to use settings context.
- Added limit to memory for Docker.
- Chunked bulk indexing to lower memory footprint.
- Fixed resource ids.
- Added debug_toolbar.
- Fixed mouse pointer on edit and delete links.
- Fixed memory usage in migration.
- Fixed collapse behavior.
- Fixed newrelic not reporting.
- Changed get_or_create to create.
- Replaced Haystack queryset and facet counts with elasticsearch-dsl.
- Fixed id attribute for vocab and term select.
- Added filtering on vocabulary and learning resource type for learning resources.
- Configured newrelic python agent.
- Implemented verification of resource types on models.
- Static assets are served again using local storage.
- Fixed missing test module.
- Replaced default missing title and updated description path.
- Pinned PyTest to a version < 2.8.
- Wrapped description text to 2 lines and added expand collapse description functionality.
