### PR TITLE
Set Elasticsearch log level higher during testing

### DIFF
--- a/lore/settings.py
+++ b/lore/settings.py
@@ -277,6 +277,7 @@ LOGIN_URL = "/admin/"
 # Logging configuration
 LOG_LEVEL = get_var('LORE_LOG_LEVEL', 'DEBUG')
 DJANGO_LOG_LEVEL = get_var('DJANGO_LOG_LEVEL', 'DEBUG')
+ES_LOG_LEVEL = get_var('ES_LOG_LEVEL', 'INFO')
 
 # For logging to a remote syslog host
 LOG_HOST = get_var('LORE_LOG_HOST', 'localhost')
@@ -339,7 +340,7 @@ LOGGING = {
             'level': 'INFO',
         },
         'elasticsearch': {
-            'level': 'INFO',
+            'level': ES_LOG_LEVEL,
         },
     },
 }

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ setenv =
     CELERY_ALWAYS_EAGER=True
     HAYSTACK_INDEX=testindex
     LORE_DB_DISABLE_SSL=True
+    ES_LOG_LEVEL=WARNING
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
Fixes #792. It looks like the increased memory use is just due to Elasticsearch logs being stored in memory.
