### PR TITLE
rc/0.13.0

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,19 @@
 Release Notes
 -------------
 
+Version 0.13.0
+==============
+
+- Refactored listing code for testing.
+- Implemented lazy loading for resource tab.
+- Added custom slugify function to allow any name for Repo, Vocab, Term.
+- Fixed index mapping of terms and vocabularies.
+- Set Elasticsearch log level higher during testing.
+- Set Spinner `zIndex` to 0 to not have it float above everything else.
+- Added loader on save.
+- Removed unused functions.
+- Fixed link click behavior for term edit and delete.
+
 Version 0.12.0
 ==============
 

--- a/learningresources/migrations/0018_fill_empty_slugs.py
+++ b/learningresources/migrations/0018_fill_empty_slugs.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.db.models import F
+
+from rest.util import default_slugify
+
+# pylint: skip-file
+
+
+def backfill_empty_slugs(apps, schema_editor):
+    """
+    Finds all the objects in the Repository
+    that do not have a slug and change the name;
+    this will automatically create a new slug.
+    """
+    Repository = apps.get_model("learningresources", "Repository")
+
+    for repo in Repository.objects.filter(slug=''):
+        repo.slug = default_slugify(
+            repo.name,
+            Repository._meta.model_name,
+            lambda slug: Repository.objects.filter(slug=slug).exists()
+        )
+        repo.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('learningresources', '0017_learningresource_missing_title_update'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_empty_slugs)
+    ]

--- a/learningresources/tests/test_models.py
+++ b/learningresources/tests/test_models.py
@@ -111,6 +111,20 @@ class TestModels(LoreTestCase):
         self.assertEqual(repo.name, "repo name")
         self.assertEqual(repo.slug, "repo-name")
 
+        # using a weird name
+        repo.name = "&^%$"
+        repo.save()
+        self.assertEqual(repo.name, "&^%$")
+        self.assertEqual(repo.slug, "repository-slug")
+        # create a new repo with weird name
+        repo = Repository.objects.create(
+            name="****&&",
+            description="description",
+            created_by_id=self.user.id,
+        )
+        self.assertEqual(repo.name, "****&&")
+        self.assertEqual(repo.slug, "repository-slug1")
+
     def test_static_asset_basepath(self):
         """Verify we are setting the path we expect"""
         filename = 'asdf/asdf.txt'

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -277,6 +277,7 @@ LOGIN_URL = "/admin/"
 # Logging configuration
 LOG_LEVEL = get_var('LORE_LOG_LEVEL', 'DEBUG')
 DJANGO_LOG_LEVEL = get_var('DJANGO_LOG_LEVEL', 'DEBUG')
+ES_LOG_LEVEL = get_var('ES_LOG_LEVEL', 'INFO')
 
 # For logging to a remote syslog host
 LOG_HOST = get_var('LORE_LOG_HOST', 'localhost')
@@ -339,7 +340,7 @@ LOGGING = {
             'level': 'INFO',
         },
         'elasticsearch': {
-            'level': 'INFO',
+            'level': ES_LOG_LEVEL,
         },
     },
 }

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -15,7 +15,7 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 import yaml
 
-VERSION = '0.12.0'
+VERSION = '0.13.0'
 
 CONFIG_PATHS = [
     os.environ.get('LORE_CONFIG', ''),

--- a/rest/tests/test_misc.py
+++ b/rest/tests/test_misc.py
@@ -15,6 +15,7 @@ from rest.tests.base import (
     as_json,
 )
 from rest.pagination import LorePagination
+from rest.util import default_slugify
 
 
 class TestMisc(RESTTestCase):
@@ -104,4 +105,46 @@ class TestMisc(RESTTestCase):
         self.assert_page_size(
             LorePagination.max_page_size - 1,
             LorePagination.max_page_size - 1
+        )
+
+    def test_default_slugify(self):
+        """
+        Test for the default slugify function.
+        Since this function is generic, here we test the generic call
+        """
+        # a normal string
+        self.assertEqual(
+            default_slugify(
+                'foo',
+                'bar',
+                lambda x: False
+            ),
+            'foo'
+        )
+        # the normal string already exists
+        self.assertEqual(
+            default_slugify(
+                'foo',
+                'bar',
+                lambda x: x == 'foo'
+            ),
+            'foo1'
+        )
+        # a string that gives an empty slug
+        self.assertEqual(
+            default_slugify(
+                '%^%$',
+                'bar',
+                lambda x: False
+            ),
+            'bar-slug'
+        )
+        # the default slug already exists
+        self.assertEqual(
+            default_slugify(
+                '%^%$',
+                'bar',
+                lambda x: x == 'bar-slug'
+            ),
+            'bar-slug1'
         )

--- a/rest/tests/test_search.py
+++ b/rest/tests/test_search.py
@@ -144,7 +144,7 @@ class TestSearch(RESTTestCase):
         Make sure we're not hitting the database for the search
         more than necessary.
         """
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9):
             self.get_results()
 
     def test_sortby(self):
@@ -289,7 +289,7 @@ class TestSearch(RESTTestCase):
         term1_results = self.get_results(
             selected_facets=["{v}_exact:{t}".format(
                 v=vocab_key,
-                t=term1.slug
+                t=term1.id
             )]
         )
         self.assertEqual(1, term1_results['count'])
@@ -297,7 +297,7 @@ class TestSearch(RESTTestCase):
         term2_results = self.get_results(
             selected_facets=["{v}_exact:{t}".format(
                 v=vocab_key,
-                t=term2.slug
+                t=term2.id
             )]
         )
         self.assertEqual(1, term2_results['count'])
@@ -385,7 +385,7 @@ class TestSearch(RESTTestCase):
         # Facet count
         facet_counts = self.get_results(
             selected_facets=["{v}_exact:{t}".format(
-                v=vocab_key, t=term1.slug
+                v=vocab_key, t=term1.id
             )]
         )['facet_counts']
         self.assertEqual(
@@ -439,7 +439,7 @@ class TestSearch(RESTTestCase):
                 },
                 'values': [{
                     'count': 1,
-                    'key': term1.slug,
+                    'key': str(term1.id),
                     'label': term1.label
                 }]
             }
@@ -492,14 +492,14 @@ class TestSearch(RESTTestCase):
 
         selected_facets = self.get_results(
             selected_facets=["{v}_exact:{t}".format(
-                v=vocab_key, t=term1.slug
+                v=vocab_key, t=term1.id
             )]
         )['selected_facets']
         self.assertEqual(
             selected_facets,
             {
                 '{v}'.format(v=vocab_key): {'{t}'.format(
-                    t=term1.slug): True},
+                    t=term1.id): True},
                 'course': {},
                 'resource_type': {},
                 'run': {}
@@ -510,7 +510,7 @@ class TestSearch(RESTTestCase):
         # we should have no checkboxes that show up.
         selected_facets = self.get_results(
             selected_facets=["{v}_exact:{t}".format(
-                v=vocab_key, t=term1.slug
+                v=vocab_key, t=term1.id
             ), "run_exact:doesnt_exist"]
         )['selected_facets']
         self.assertEqual(
@@ -546,12 +546,17 @@ class TestSearch(RESTTestCase):
         vocab_dict['learning_resource_types'] = [
             self.resource.learning_resource_type.name
         ]
-        vocab_slug = self.create_vocabulary(self.repo.slug, vocab_dict)['slug']
-        term_slug = self.create_term(self.repo.slug, vocab_slug, {
+        vocab_result = self.create_vocabulary(self.repo.slug, vocab_dict)
+        vocab_slug = vocab_result['slug']
+        vocab_id = vocab_result['id']
+        vocab_key = make_vocab_key(vocab_id)
+
+        term_result = self.create_term(self.repo.slug, vocab_slug, {
             "label": "empty",
             "weight": 4
-        })['slug']
-        vocab_key = make_vocab_key(vocab_slug)
+        })
+        term_id = term_result['id']
+        term_slug = term_result['slug']
 
         # There is one resource and it is missing a term.
         # Test that a missing search will get one result.
@@ -566,7 +571,7 @@ class TestSearch(RESTTestCase):
         results = self.get_results(
             selected_facets=["{v}_exact:{t}".format(
                 v=vocab_key,
-                t=term_slug
+                t=term_id
             )]
         )
         self.assertEqual(results['count'], 0)
@@ -592,7 +597,7 @@ class TestSearch(RESTTestCase):
         results = self.get_results(
             selected_facets=["{v}_exact:{t}".format(
                 v=vocab_key,
-                t=term_slug
+                t=term_id
             )]
         )
         self.assertEqual(results['count'], 1)
@@ -645,14 +650,14 @@ class TestSearch(RESTTestCase):
         self.assertEqual(
             self.get_results(selected_facets=["{v}_exact:{t}".format(
                 v=vocab1_key,
-                t=term1.slug
+                t=term1.id
             )])['count'],
             0
         )
         self.assertEqual(
             self.get_results(selected_facets=["{v}_exact:{t}".format(
                 v=vocab2_key,
-                t=term2.slug
+                t=term2.id
             )])['count'],
             1
         )
@@ -663,14 +668,14 @@ class TestSearch(RESTTestCase):
         self.assertEqual(
             self.get_results(selected_facets=["{v}_exact:{t}".format(
                 v=vocab1_key,
-                t=term1.slug
+                t=term1.id
             )])['count'],
             1
         )
         self.assertEqual(
             self.get_results(selected_facets=["{v}_exact:{t}".format(
                 v=vocab2_key,
-                t=term2.slug
+                t=term2.id
             )])['count'],
             0
         )

--- a/rest/tests/test_vocabulary.py
+++ b/rest/tests/test_vocabulary.py
@@ -24,7 +24,7 @@ from rest.serializers import (
     VocabularySerializer,
     TermSerializer,
 )
-from taxonomy.models import Vocabulary, Term
+from taxonomy.models import Vocabulary, Term, make_vocab_key
 from learningresources.models import LearningResourceType, LearningResource
 
 log = logging.getLogger(__name__)
@@ -668,8 +668,8 @@ class TestVocabulary(RESTTestCase):
                     self.get_results()['facet_counts'][vocab_key]['values']]),
             []
         )
-        self.assert_results([], vocab_key, term1.slug)
-        self.assert_results([], vocab_key, term2.slug)
+        self.assert_results([], vocab_key, term1.id)
+        self.assert_results([], vocab_key, term2.id)
 
         resource1 = LearningResource.objects.all()[0]
         resource2 = LearningResource.objects.all()[1]
@@ -684,11 +684,11 @@ class TestVocabulary(RESTTestCase):
         self.assertEqual(
             sorted([t['key'] for t in
                     self.get_results()['facet_counts'][vocab_key]['values']]),
-            sorted([term1.slug, term2.slug])
+            sorted([str(term1.id), str(term2.id)])
         )
 
-        self.assert_results([resource1], vocab_key, term1.slug)
-        self.assert_results([resource2], vocab_key, term2.slug)
+        self.assert_results([resource1], vocab_key, term1.id)
+        self.assert_results([resource2], vocab_key, term2.id)
 
     def test_index_updates_on_edit(self):
         """
@@ -732,8 +732,8 @@ class TestVocabulary(RESTTestCase):
                     self.get_results()['facet_counts'][vocab_key]['values']]),
             []
         )
-        self.assert_results([], vocab_key, term1.slug)
-        self.assert_results([], vocab_key, term2.slug)
+        self.assert_results([], vocab_key, term1.id)
+        self.assert_results([], vocab_key, term2.id)
 
         resource1 = LearningResource.objects.all()[0]
         resource2 = LearningResource.objects.all()[1]
@@ -748,10 +748,10 @@ class TestVocabulary(RESTTestCase):
         self.assertEqual(
             sorted([t['key'] for t in
                     self.get_results()['facet_counts'][vocab_key]['values']]),
-            sorted([term1.slug, term2.slug])
+            sorted([str(term1.id), str(term2.id)])
         )
-        self.assert_results([resource1], vocab_key, term1.slug)
-        self.assert_results([resource2], vocab_key, term2.slug)
+        self.assert_results([resource1], vocab_key, term1.id)
+        self.assert_results([resource2], vocab_key, term2.id)
 
         # Vocab is edited to remove all learning resource types which will also
         # remove all links to terms.
@@ -765,8 +765,8 @@ class TestVocabulary(RESTTestCase):
                     self.get_results()['facet_counts'][vocab_key]['values']]),
             []
         )
-        self.assert_results([], vocab_key, term1.slug)
-        self.assert_results([], vocab_key, term2.slug)
+        self.assert_results([], vocab_key, term1.id)
+        self.assert_results([], vocab_key, term2.id)
 
     def test_index_updates_on_delete(self):
         """
@@ -825,20 +825,20 @@ class TestVocabulary(RESTTestCase):
         self.assertEqual(
             sorted([t['key'] for t in
                     self.get_results()['facet_counts'][vocab_key]['values']]),
-            sorted([term1.slug, term2.slug])
+            sorted([str(term1.id), str(term2.id)])
         )
-        self.assert_results([resource1], vocab_key, term1.slug)
-        self.assert_results([resource2], vocab_key, term2.slug)
+        self.assert_results([resource1], vocab_key, term1.id)
+        self.assert_results([resource2], vocab_key, term2.id)
 
         # Term is removed from facet list.
         self.delete_term(self.repo.slug, vocab.slug, term1.slug)
         self.assertEqual(
             sorted([t['key'] for t in
                     self.get_results()['facet_counts'][vocab_key]['values']]),
-            sorted([term2.slug])
+            sorted([str(term2.id)])
         )
-        self.assert_results([], vocab_key, term1.slug)
-        self.assert_results([resource2], vocab_key, term2.slug)
+        self.assert_results([], vocab_key, term1.id)
+        self.assert_results([resource2], vocab_key, term2.id)
 
         self.delete_vocabulary(self.repo.slug, vocab.slug)
         # No vocabs left.
@@ -846,8 +846,8 @@ class TestVocabulary(RESTTestCase):
             sorted(["course", "run", "resource_type"]),
             sorted(self.get_results()['facet_counts'].keys())
         )
-        self.assert_results([], vocab_key, term1.slug)
-        self.assert_results([], vocab_key, term2.slug)
+        self.assert_results([], vocab_key, term1.id)
+        self.assert_results([], vocab_key, term2.id)
 
     def test_vocab_num_queries(self):
         """Make sure number of queries is reasonable for vocab and term."""
@@ -895,6 +895,133 @@ class TestVocabulary(RESTTestCase):
         })
         with self.assertNumQueries(30):
             self.delete_vocabulary(self.repo.slug, vocab_slug)
+
+    def test_vocabulary_rename(self):
+        """Test that index updates properly after a vocabulary rename."""
+        vocab_result = self.create_vocabulary(self.repo.slug)
+        vocab_id = vocab_result['id']
+        vocab_key = make_vocab_key(vocab_id)
+        vocab_slug = vocab_result['slug']
+        term_result = self.create_term(self.repo.slug, vocab_slug)
+        term_id = term_result['id']
+        term_slug = term_result['slug']
+        term_label = term_result['label']
+
+        # Update vocabulary for resource type, assign term
+        self.patch_vocabulary(self.repo.slug, vocab_slug, {
+            "learning_resource_types": [
+                self.resource.learning_resource_type.name
+            ]
+        })
+        self.patch_learning_resource(self.repo.slug, self.resource.id, {
+            "terms": [term_slug]
+        })
+
+        self.assertEqual(
+            self.get_results()['facet_counts'][vocab_key]['facet']['label'],
+            vocab_result['name']
+        )
+        self.assertEqual(
+            self.get_results()['facet_counts'][vocab_key]['values'],
+            [{'count': 1, 'key': str(term_id), 'label': term_label}]
+        )
+        self.assertEqual(
+            self.get_results(selected_facets=["{v}_exact:{t}".format(
+                v=vocab_key,
+                t=term_id
+            )])['count'],
+            1
+        )
+
+        # Rename vocabulary
+        name = "brand new name"
+        self.patch_vocabulary(self.repo.slug, vocab_slug, {
+            "name": name
+        })
+
+        # Facet counts should not change
+        self.assertEqual(
+            self.get_results()['facet_counts'][vocab_key]['facet']['label'],
+            name
+        )
+        self.assertEqual(
+            self.get_results()['facet_counts'][vocab_key]['values'],
+            [{'count': 1, 'key': str(term_id), 'label': term_label}]
+        )
+        self.assertEqual(
+            self.get_results(selected_facets=["{v}_exact:{t}".format(
+                v=vocab_key,
+                t=term_id
+            )])['count'],
+            1
+        )
+
+    def test_term_rename(self):
+        """Test that index updates properly after a term rename."""
+        vocab_result = self.create_vocabulary(self.repo.slug)
+        vocab_key = make_vocab_key(vocab_result['id'])
+        vocab_slug = vocab_result['slug']
+        term_result = self.create_term(self.repo.slug, vocab_slug)
+        term_id = term_result['id']
+        term_slug = term_result['slug']
+
+        # Update vocabulary for resource type, assign term
+        self.patch_vocabulary(self.repo.slug, vocab_slug, {
+            "learning_resource_types": [
+                self.resource.learning_resource_type.name
+            ]
+        })
+        self.patch_learning_resource(self.repo.slug, self.resource.id, {
+            "terms": [term_slug]
+        })
+
+        self.assertEqual(
+            self.get_results()['facet_counts'][vocab_key]['values'],
+            [{'count': 1, 'key': str(term_id), 'label': term_result['label']}]
+        )
+        self.assertEqual(
+            self.get_results(selected_facets=["{v}_exact:{t}".format(
+                v=vocab_key,
+                t=term_id
+            )])['count'],
+            1
+        )
+
+        # Rename term
+        label = "brand new label"
+        self.patch_term(self.repo.slug, vocab_slug, term_slug, {
+            "label": label
+        })
+
+        # Facet counts should not change
+        self.assertEqual(
+            self.get_results()['facet_counts'][vocab_key]['values'],
+            [{'count': 1, 'key': str(term_id), 'label': label}]
+        )
+        self.assertEqual(
+            self.get_results(selected_facets=["{v}_exact:{t}".format(
+                v=vocab_key,
+                t=term_id
+            )])['count'],
+            1
+        )
+
+    def test_empty_vocab_facet_count(self):
+        """
+        Test that we get vocabulary label and not something else for
+        an empty vocabulary.
+        """
+        vocab_dict = dict(self.DEFAULT_VOCAB_DICT)
+        name = 'name with spaces'
+        vocab_dict['name'] = name
+        vocab_result = self.create_vocabulary(self.repo.slug, vocab_dict)
+        vocab_id = vocab_result['id']
+        vocab_key = make_vocab_key(vocab_id)
+
+        self.assertEqual(
+            self.get_results()['facet_counts'][vocab_key]['facet']['label'],
+            name
+        )
 
 
 class TestVocabularyAuthorization(RESTAuthTestCase):

--- a/rest/util.py
+++ b/rest/util.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 from django.contrib.auth.models import User
 from django.http.response import Http404
 from django.shortcuts import get_object_or_404
+from django.utils.text import slugify
 from rest_framework.fields import BooleanField, empty
 
 from roles.permissions import BaseGroupTypes
@@ -60,3 +61,28 @@ class CheckValidMemberParamMixin(object):
             CheckValidMemberParamMixin,
             self
         ).dispatch(request, *args, **kwargs)
+
+
+def default_slugify(label, default_name, exists_func):
+    """
+    Function that extends the Django `slugify` to add a default string in case
+    the slugified string is empty.
+    It also takes care of collisions.
+    NOTE: the `exists_func` must be a valid function to verify the existence
+    of the slug. The implementation is left to the coder's discretion.
+
+    Args:
+        label (unicode): label to be slugified
+        default_name (unicode): default base slug to be used if the slugified
+            label is an empty string
+        exists_func (function): function to be used to verify if
+            a slug is already in use
+    Returns:
+        slug (unicode): slug for the label
+    """
+    slug = slugified_str = slugify(label) or '{}-slug'.format(default_name)
+    count = 1
+    while exists_func(slug):
+        slug = "{0}{1}".format(slugified_str, count)
+        count += 1
+    return slug

--- a/search/tests/base_es.py
+++ b/search/tests/base_es.py
@@ -46,9 +46,9 @@ class SearchTestCase(LoreTestCase):
         """Return count of matching indexed records."""
         return self.search(query).count()
 
-    def count_faceted_results(self, vocab, term):
+    def count_faceted_results(self, vocab_id, term_id):
         """Return count of matching indexed records by facet."""
         return search_index(
             repo_slug=self.repo.slug,
-            terms={make_vocab_key(vocab): term}
+            terms={make_vocab_key(vocab_id): term_id}
         ).count()

--- a/search/tests/test_es_indexing.py
+++ b/search/tests/test_es_indexing.py
@@ -160,15 +160,15 @@ class TestIndexing(SearchTestCase):
         set_cache_timeout(0)
         term = self.terms[0]
         self.assertEqual(self.count_faceted_results(
-            self.vocabulary.name, term.label), 0)
+            self.vocabulary.id, term.id), 0)
         self.resource.terms.add(term)
         refresh_index()
         self.assertEqual(self.count_faceted_results(
-            self.vocabulary.name, term.label), 1)
+            self.vocabulary.id, term.id), 1)
         self.resource.terms.remove(term)
         refresh_index()
         self.assertEqual(self.count_faceted_results(
-            self.vocabulary.name, term.label), 0)
+            self.vocabulary.id, term.id), 0)
 
     def test_strip_xml(self):
         """Indexed content_xml should have XML stripped."""

--- a/search/tests/test_indexing.py
+++ b/search/tests/test_indexing.py
@@ -62,11 +62,11 @@ class TestIndexing(SearchTestCase):
         vocab_key = self.vocabulary.index_key
         set_cache_timeout(0)
         term = self.terms[0]
-        self.assertEqual(self.count_faceted_results(vocab_key, term.slug), 0)
+        self.assertEqual(self.count_faceted_results(vocab_key, term.id), 0)
         self.resource.terms.add(term)
-        self.assertEqual(self.count_faceted_results(vocab_key, term.slug), 1)
+        self.assertEqual(self.count_faceted_results(vocab_key, term.id), 1)
         self.resource.terms.remove(term)
-        self.assertEqual(self.count_faceted_results(vocab_key, term.slug), 0)
+        self.assertEqual(self.count_faceted_results(vocab_key, term.id), 0)
 
     def test_strip_xml(self):
         """Indexed content_xml should have XML stripped."""

--- a/taxonomy/api.py
+++ b/taxonomy/api.py
@@ -52,32 +52,3 @@ def get_term(repo_slug, user_id, vocab_slug, term_slug):
         raise NotFound()
     except Term.DoesNotExist:
         raise NotFound()
-
-
-# pylint: disable=too-many-arguments
-def create_vocabulary(
-        user_id, repo_slug, name, description,
-        required=False, vocabulary_type=Vocabulary.MANAGED, weight=0,
-        multi_terms=False):
-    """
-    Create a new vocabulary.
-    Args:
-        user_id (int): primary key of the User
-        repo_slug (unicode): slug of the repository
-        name (unicode): vocab name
-        description (unicode): vocab description
-        required (bool): is it required?
-        vocabulary_type (unicode): on of the Vocabulary.vocabulary_type options
-        weight (int): vocab weight
-        multi_terms (bool): multiple terms possible on one LearningResource
-    Returns:
-        vocab (Vocabulary)
-    """
-    repo = get_repo(repo_slug, user_id)
-    vocab = Vocabulary.objects.create(
-        repository_id=repo.id,
-        name=name, description=description,
-        required=required, vocabulary_type=vocabulary_type,
-        weight=weight, multi_terms=multi_terms
-    )
-    return vocab

--- a/taxonomy/migrations/0008_fill_empty_slugs.py
+++ b/taxonomy/migrations/0008_fill_empty_slugs.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.db.models import F
+
+from rest.util import default_slugify
+
+# pylint: skip-file
+
+
+def backfill_empty_slugs(apps, schema_editor):
+    """
+    Finds all the objects in the Repository
+    that do not have a slug and change the name;
+    this will automatically create a new slug.
+    """
+    Vocabulary = apps.get_model("taxonomy", "Vocabulary")
+    Term = apps.get_model("taxonomy", "Term")
+
+    for vocab in Vocabulary.objects.filter(slug=''):
+        vocab.slug = default_slugify(
+            vocab.name,
+            Vocabulary._meta.model_name,
+            lambda slug: Vocabulary.objects.filter(slug=slug).exists()
+        )
+        vocab.save()
+    for term in Term.objects.filter(slug=''):
+        term.slug = default_slugify(
+            term.label,
+            Term._meta.model_name,
+            lambda slug: Term.objects.filter(slug=slug).exists()
+        )
+        term.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taxonomy', '0007_vocabulary_multi_terms'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_empty_slugs)
+    ]

--- a/taxonomy/models.py
+++ b/taxonomy/models.py
@@ -14,11 +14,11 @@ from learningresources.models import (
 )
 
 
-def make_vocab_key(vocab_slug):
+def make_vocab_key(vocab_id):
     """
     Create vocab key used for elasticsearch index mapping.
     """
-    return "vocab_{slug}".format(slug=vocab_slug)
+    return "vocab_{id}".format(id=vocab_id)
 
 
 class Vocabulary(BaseModel):
@@ -71,7 +71,7 @@ class Vocabulary(BaseModel):
     @property
     def index_key(self):
         """Key used in elasticsearch index."""
-        return make_vocab_key(self.slug)
+        return make_vocab_key(self.id)
 
 
 class Term(BaseModel):

--- a/taxonomy/models.py
+++ b/taxonomy/models.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from django.db import models, transaction
 from django.utils.translation import ugettext_lazy as _
-from django.utils.text import slugify
 from django.shortcuts import get_object_or_404
 
 from audit.models import BaseModel
@@ -12,6 +11,7 @@ from learningresources.models import (
     LearningResourceType,
     LearningResource,
 )
+from rest.util import default_slugify
 
 
 def make_vocab_key(vocab_slug):
@@ -59,12 +59,11 @@ class Vocabulary(BaseModel):
         """Handle slugs."""
         if self.id is None or self.name != get_object_or_404(
                 Vocabulary, id=self.id).name:
-            slug = slugify(self.name)
-            count = 1
-            while Vocabulary.objects.filter(slug=slug).exists():
-                slug = "{0}{1}".format(slugify(self.name), count)
-                count += 1
-            self.slug = slug
+            self.slug = default_slugify(
+                self.name,
+                Vocabulary._meta.model_name,
+                lambda slug: Vocabulary.objects.filter(slug=slug).exists()
+            )
 
         return super(Vocabulary, self).save(*args, **kwargs)
 
@@ -95,10 +94,9 @@ class Term(BaseModel):
         """Handle slugs."""
         if self.id is None or self.label != get_object_or_404(
                 Term, id=self.id).label:
-            slug = slugify(self.label)
-            count = 1
-            while Term.objects.filter(slug=slug).exists():
-                slug = "{0}{1}".format(slugify(self.label), count)
-                count += 1
-            self.slug = slug
+            self.slug = default_slugify(
+                self.label,
+                Term._meta.model_name,
+                lambda slug: Term.objects.filter(slug=slug).exists()
+            )
         return super(Term, self).save(*args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ setenv =
     CELERY_ALWAYS_EAGER=True
     HAYSTACK_INDEX=testindex
     LORE_DB_DISABLE_SSL=True
+    ES_LOG_LEVEL=WARNING
 
 [testenv:docs]
 basepython = python2.7

--- a/ui/jstests/test_manage_taxonomies.jsx
+++ b/ui/jstests/test_manage_taxonomies.jsx
@@ -211,6 +211,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         errorMessage = message;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var afterMount = function(component) {
         var labels = React.addons.TestUtils.
         scryRenderedDOMComponentsWithTag(
@@ -260,8 +265,10 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             assert.equal(refreshCount, 0);
             React.addons.TestUtils.Simulate.click(saveButton);
             component.forceUpdate(function() {
+              assert.equal(loadedState, false);
               //after saved term using api
               waitForAjax(1, function() {
+                assert.equal(loadedState, true);
                 //term state reset
                 assert.equal(component.state.formatActionState, 'show');
                 // term is update in parent
@@ -392,6 +399,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             vocabulary={vocabulary}
             refreshFromAPI={refreshFromAPI}
             reportMessage={reportMessage}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -422,6 +430,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
       var refreshCount = 0;
       var refreshFromAPI = function() {
         refreshCount++;
+      };
+
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
       };
 
       var afterMount = function(component) {
@@ -481,7 +494,10 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
                 assert.equal(refreshCount, 0);
                 React.addons.TestUtils.Simulate.click(saveButton);
                 component.forceUpdate(function() {
+                  // Loader is spinning...
+                  assert.equal(loadedState, false);
                   waitForAjax(1, function() {
+                    assert.equal(loadedState, true);
                     assert.equal(component.state.label, "TestB");
                     assert.equal(
                       component.state.errorMessage, 'Unable to update term'
@@ -530,6 +546,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateTerm={updateTerm}
             vocabulary={vocabulary}
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -564,6 +581,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         refreshCount++;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var afterMount = function(component) {
         var deleteButton = React.addons.TestUtils.
           findRenderedDOMComponentWithClass(
@@ -573,8 +595,10 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         //select delete
         React.addons.TestUtils.Simulate.click(deleteButton);
         component.forceUpdate(function() {
+          assert.equal(loadedState, false);
           assert.equal(component.state.formatActionState, 'show');
           waitForAjax(1, function() {
+            assert.equal(loadedState, true);
             // term is delete in parent
             assert.equal(parentUpdateCount, 1);
             // listing was asked to refresh
@@ -593,6 +617,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             deleteTerm={deleteTerm}
             vocabulary={vocabulary}
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -629,6 +654,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         refreshCount++;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var afterMount = function(component) {
         var deleteButton = React.addons.TestUtils.
           findRenderedDOMComponentWithClass(
@@ -642,7 +672,9 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             component.state.errorMessage, ''
           );
           assert.equal(component.state.formatActionState, 'show');
+          assert.equal(loadedState, false);
           waitForAjax(1, function() {
+            assert.equal(loadedState, true);
             // check state of error message
             assert.equal(
               component.state.errorMessage, 'Unable to delete term.'
@@ -661,6 +693,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             deleteTerm={deleteTerm}
             vocabulary={vocabulary}
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -693,6 +726,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
       };
 
       var reportMessage = function() {};
+
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
 
       var refreshCount = 0;
       var refreshFromAPI = function() {
@@ -783,7 +821,9 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
                   React.addons.TestUtils.Simulate.keyUp(
                     textbox, {key: "Enter"}
                   );
+                  assert.equal(loadedState, false);
                   waitForAjax(1, function () {
+                    assert.equal(loadedState, true);
                     assert.equal(addTermCalled, 1);
                     done();
                   });
@@ -805,6 +845,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             addTerm={addTerm}
             repoSlug="repo"
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -838,12 +879,19 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         refreshCount++;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var afterMount = function(component) {
         // wait for calls to populate form
         var node = React.findDOMNode(component);
         var textbox = $(node).find("input")[0];
         React.addons.TestUtils.Simulate.keyUp(textbox, {key: "Enter"});
+        assert.equal(loadedState, false);
         waitForAjax(1, function () {
+          assert.equal(loadedState, true);
           assert.equal(addTermCalled, 0);
           // refreshFromAPI was never called
           assert.equal(refreshCount, 0);
@@ -864,6 +912,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             addTerm={addTerm}
             repoSlug="repo"
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -895,6 +944,11 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
         errorMessage = message;
       };
 
+      var loadedState;
+      var setLoadedState = function(loaded) {
+        loadedState = loaded;
+      };
+
       var editVocabulary = function() {};
       var afterMount = function(component) {
         assert.equal(
@@ -922,12 +976,16 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
               'input'
             );
           React.addons.TestUtils.Simulate.keyUp(textbox, {key: "Enter"});
-          waitForAjax(1, function() {
-            //test items
-            assert.equal(addTermCalled, 1);
-            // listing page was asked to update
-            assert.equal(refreshCount, 1);
-            done();
+          component.forceUpdate(function() {
+            assert.equal(loadedState, false);
+            waitForAjax(1, function () {
+              assert.equal(loadedState, true);
+              //test items
+              assert.equal(addTermCalled, 1);
+              // listing page was asked to update
+              assert.equal(refreshCount, 1);
+              done();
+            });
           });
         });
       };
@@ -940,6 +998,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             addTerm={addTerm}
             refreshFromAPI={refreshFromAPI}
             reportMessage={reportMessage}
+            setLoadedState={setLoadedState}
             ref={afterMount}
           />
         );
@@ -1168,6 +1227,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             learningResourceTypes={propLearningResourceTypes}
             refreshFromAPI={refreshFromAPI}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1260,6 +1320,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             refreshFromAPI={refreshFromAPI}
             reportMessage={reportMessage}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1361,6 +1422,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             refreshFromAPI={refreshFromAPI}
             updateParent={updateParent}
             reportMessage={reportMessage}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1506,6 +1568,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             reportMessage={reportMessage}
             renderConfirmationDialog={renderConfirmationDialog}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1513,7 +1576,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
   );
 
   QUnit.test('Assert that if user cancels update vocabulary dialog, no change' +
-    'is made',
+    ' is made',
     function(assert) {
       assert.ok(AddVocabulary, "class object not found");
       var done = assert.async();
@@ -1591,6 +1654,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             );
             component.forceUpdate(function () {
               React.addons.TestUtils.Simulate.click(updateButton);
+              // Check that loader turns on and off.
               component.forceUpdate(function () {
                 waitForAjax(1, function () {
                   var expected = {
@@ -1626,6 +1690,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             reportMessage={reportMessage}
             renderConfirmationDialog={renderConfirmationDialog}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1743,6 +1808,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             reportMessage={reportMessage}
             renderConfirmationDialog={renderConfirmationDialog}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1833,6 +1899,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             refreshFromAPI={refreshFromAPI}
             updateParent={updateParent}
             reportMessage={reportMessage}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );
@@ -1925,6 +1992,7 @@ define(['QUnit', 'jquery', 'lodash', 'manage_taxonomies', 'react',
             updateParent={updateParent}
             refreshFromAPI={refreshFromAPI}
             reportMessage={reportMessage}
+            setLoadedState={function() {}}
             ref={afterMount}
           />
         );

--- a/ui/static/ui/js/listing.js
+++ b/ui/static/ui/js/listing.js
@@ -226,7 +226,7 @@ define('listing',
       var selectedFacets;
       var selectedMissingFacets;
 
-      var openResourcePanel = function(resourceId) {
+      var loadResourceTab = function(resourceId) {
         LearningResources.loader(
           repoSlug,
           resourceId,
@@ -234,10 +234,48 @@ define('listing',
           closeLearningResourcePanel,
           $("#tab-1")[0]
         );
-        $('.cd-panel').addClass('is-visible');
-        StaticAssets.loader(repoSlug, resourceId, $("#tab-3")[0]);
+      };
+
+      var loadXmlTab = function(resourceId) {
         XmlPanel.loader(repoSlug, resourceId, $("#tab-2")[0]);
       };
+
+      var loadStaticAssetsTab = function(resourceId) {
+        StaticAssets.loader(repoSlug, resourceId, $("#tab-3")[0]);
+      };
+
+      // Keep track of resource id so we can lazy load panels.
+      var currentResourceId;
+
+      var panelLoaders = {
+        "tab-1": loadResourceTab,
+        "tab-2": loadXmlTab,
+        "tab-3": loadStaticAssetsTab
+      };
+
+      var loadedPanels;
+      var openResourcePanel = function(resourceId) {
+        // Reset loaded panels
+        loadedPanels = {};
+        currentResourceId = resourceId;
+
+        // Load the resource tab
+        showTab("tab-1");
+        loadResourceTab(currentResourceId);
+        loadedPanels["tab-1"] = true;
+
+        $('.cd-panel').addClass('is-visible');
+      };
+
+      _.each(panelLoaders, function(loader, tag) {
+        $("a[href='#" + tag + "']").click(function() {
+          // If tab not already loaded, load it now
+          if (!loadedPanels[tag]) {
+            loader(currentResourceId);
+            loadedPanels[tag] = true;
+          }
+        });
+      });
 
       refreshFromAPI = function() {
         pageLoaded = false;

--- a/ui/static/ui/js/listing.js
+++ b/ui/static/ui/js/listing.js
@@ -1,218 +1,229 @@
 define('listing',
-  ['csrf', 'jquery', 'lodash', 'uri', 'history', 'manage_taxonomies',
+  ['csrf', 'react', 'jquery', 'lodash', 'uri', 'history', 'manage_taxonomies',
     'learning_resources', 'static_assets', 'utils',
-    'lr_exports', 'listing_resources', 'pagination', 'xml_panel',
+    'lr_exports', 'listing_resources', 'xml_panel',
     'bootstrap', 'icheck'],
-  function (CSRF, $, _, URI, History,
+  function (CSRF, React, $, _, URI, History,
             ManageTaxonomies, LearningResources, StaticAssets,
-            Utils, Exports, ListingResources, Pagination, XmlPanel) {
+            Utils, Exports, ListingResources, XmlPanel) {
     'use strict';
 
-    var loader = function (listingOptions, container) {
-      var repoSlug = listingOptions.repoSlug;
-      var loggedInUsername = listingOptions.loggedInUsername;
+    var EMAIL_EXTENSION = '@mit.edu';
 
-      // empty results and facetCounts to start with
-      listingOptions = $.extend({}, listingOptions);
-      listingOptions.resources = [];
-      listingOptions.facetCounts = {};
+    function formatGroupName(string) {
+      string = string.charAt(0).toUpperCase() + string.slice(1);
+      return string.substring(0, string.length - 1);
+    }
 
-      CSRF.setupCSRF();
+    /* This is going to grow up to check whether
+     * the name is a valid Kerberos account
+     */
+    function isEmail(email) {
+      var regex = /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i;
+      return regex.test(email);
+    }
 
-      var EMAIL_EXTENSION = '@mit.edu';
-
-      function formatGroupName(string) {
-        string = string.charAt(0).toUpperCase() + string.slice(1);
-        return string.substring(0, string.length - 1);
+    function formatUserGroups(userList, dest) {
+      var $dest = $(dest);
+      for (var i = 0; i < userList.length; i++) {
+        $dest.append(
+          '<div class="row">' +
+          '<div class="col-sm-7">' +
+          '<div class="cd-panel-members-list-username">' +
+          userList[i].username + EMAIL_EXTENSION + '</div>' +
+          '</div>\n' +
+          '<div class="col-sm-3">' +
+          '<div class="cd-panel-members-list-group_type">' +
+          formatGroupName(userList[i].group_type) + '</div>' +
+          '</div>\n' +
+          '<div class="col-sm-2">' +
+          '<button ' +
+          'class="btn btn-default cd-panel-members-remove" ' +
+          'data-username="' + userList[i].username + '" ' +
+          'data-group_type="' + userList[i].group_type + '">' +
+          '<i class="fa fa-minus"></i>' +
+          '</button>' +
+          '</div>' +
+          '</div>\n');
       }
+    }
 
-      /* This is going to grow up to check whether
-       * the name is a valid Kerberos account
-       */
-      function isEmail(email) {
-        var regex = /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i;
-        return regex.test(email);
-      }
+    function resetUserGroupForm() {
+      $('input[name=\'members-username\']').val('');
+      $('select[name=\'members-group_type\']').prop('selectedIndex', 0);
+    }
 
-      function formatUserGroups(userList, dest) {
-        var $dest = $(dest);
-        for (var i = 0; i < userList.length; i++) {
-          $dest.append(
-            '<div class="row">' +
-            '<div class="col-sm-7">' +
-            '<div class="cd-panel-members-list-username">' +
-            userList[i].username + EMAIL_EXTENSION + '</div>' +
-            '</div>\n' +
-            '<div class="col-sm-3">' +
-            '<div class="cd-panel-members-list-group_type">' +
-            formatGroupName(userList[i].group_type) + '</div>' +
-            '</div>\n' +
-            '<div class="col-sm-2">' +
-            '<button ' +
-            'class="btn btn-default cd-panel-members-remove" ' +
-            'data-username="' + userList[i].username + '" ' +
-            'data-group_type="' + userList[i].group_type + '">' +
-            '<i class="fa fa-minus"></i>' +
-            '</button>' +
-            '</div>' +
-            '</div>\n');
-        }
-      }
+    function showMembersAlert(message, mtype) {
+      //default value for mtype
+      mtype = typeof mtype !== 'undefined' ? mtype : 'success';
+      //reset all the classes
+      $('#members-alert').html(
+        '<div class="alert alert-' + mtype +
+        ' fade in out" data-alert="alert">' +
+        '<a href="#" class="close" data-dismiss="alert" ' +
+        'aria-label="close">&times;</a>\n' + message +
+        '</div>');
+    }
 
-      function resetUserGroupForm() {
-        $('input[name=\'members-username\']').val('');
-        $('select[name=\'members-group_type\']').prop('selectedIndex', 0);
-      }
+    function showUpdateAllMembers() {
+      //retrieve all the members
+      var url = $('.cd-panel-members').data('members-url');
+      return Utils.getCollection(url)
+        .then(function (results) {
+          $('#cd-panel-members-list').empty();
+          formatUserGroups(results, '#cd-panel-members-list');
+        })
+        .fail(function () {
+          var message = 'Unable to retrieve list of members.';
+          showMembersAlert(message, 'danger');
+        });
+    }
+    function closeLearningResourcePanel() {
+      $('.cd-panel').removeClass('is-visible');
+    }
 
-      function showMembersAlert(message, mtype) {
-        //default value for mtype
-        mtype = typeof mtype !== 'undefined' ? mtype : 'success';
-        //reset all the classes
-        $('#members-alert').html(
-          '<div class="alert alert-' + mtype +
-          ' fade in out" data-alert="alert">' +
-          '<a href="#" class="close" data-dismiss="alert" ' +
-          'aria-label="close">&times;</a>\n' + message +
-          '</div>');
-      }
+    var hideTaxonomyPanel = function () {
+      $('.cd-panel-2').removeClass('is-visible');
+    };
 
-      function showUpdateAllMembers() {
-        //retrieve all the members
-        var url = $('.cd-panel-members').data('members-url');
-        return Utils.getCollection(url)
-          .then(function (results) {
-            $('#cd-panel-members-list').empty();
-            formatUserGroups(results, '#cd-panel-members-list');
-          })
-          .fail(function () {
-            var message = 'Unable to retrieve list of members.';
-            showMembersAlert(message, 'danger');
-          });
-      }
-      function closeLearningResourcePanel() {
-        $('.cd-panel').removeClass('is-visible');
-      }
+    var showTab = function (tabId) {
+      $("a[href='#" + tabId + "']").tab('show');
+    };
 
-      var hideTaxonomyPanel = function() {
-        $('.cd-panel-2').removeClass('is-visible');
-      };
+    var setTabName = function (tabId, newTabName) {
+      $("a[href='#" + tabId + "']").find("span").text(newTabName);
+    };
 
-      var showTab = function(tabId) {
-        $("a[href='#" + tabId + "'").tab('show');
-      };
+    var showConfirmationDialog = function (options) {
+      var container = $("#confirmation-container")[0];
+      Utils.showConfirmationDialog(
+        options,
+        container
+      );
+    };
 
-      var setTabName = function(tabId, newTabName) {
-        $("a[href='#" + tabId + "']").find("span").text(newTabName);
-      };
-
-      var loadManageTaxonomies = function () {
-        ManageTaxonomies.loader(
-          repoSlug,
-          $('#taxonomy-component')[0],
-          showConfirmationDialog,
-          showTab,
-          setTabName,
-          refreshFromAPI
-        );
-      };
-
-      $('[data-toggle=popover]').popover();
-      //Close panels on escape keypress
-      $(document).keyup(function(event) {
-        if (event.keyCode === 27) { // escape key maps to keycode `27`
-          closeLearningResourcePanel();
-          if ($('.cd-panel-2').hasClass('is-visible')) {
-            hideTaxonomyPanel();
+    var ListingContainer = React.createClass({
+      displayName: 'ListingContainer',
+      // make data structure to store query parameters
+      makeQueryMap: function() {
+        var queryMap = {};
+        // Populate queryMap with query string key value pairs.
+        _.each(URI(this.props.getQueryString()).query(true), function (v, k) {
+          if (!Array.isArray(v)) {
+            // URI().query(true) will put two or more values with the same
+            // key in an array and not use an array for single values.
+            // Put everything into arrays for consistency's sake.
+            queryMap[k] = [v];
+          } else {
+            queryMap[k] = v;
           }
-          if ($('.cd-panel-exports').hasClass('is-visible')) {
-            $('.cd-panel-exports').removeClass('is-visible');
-          }
-          if ($('.cd-panel-members').hasClass('is-visible')) {
-            $('.cd-panel-members').removeClass('is-visible');
-          }
-          event.preventDefault();
+        });
+        return queryMap;
+      },
+      // Return query portion of URL
+      makeQueryString: function(queryMap) {
+        var newQuery = "?" + URI().search(queryMap).query();
+        if (newQuery === "?") {
+          newQuery = "";
         }
-      });
-
-      //close the lateral panel
-      $('.cd-panel').on('click', function (event) {
-        if ($(event.target).is('.cd-panel') ||
-          $(event.target).is('.cd-panel-close')) {
-          closeLearningResourcePanel();
-          event.preventDefault();
+        return newQuery;
+      },
+      // Update URL in browser
+      updateQuery: function(queryMap) {
+        var newQuery = this.makeQueryString(queryMap);
+        this.props.updateQueryString(newQuery);
+      },
+      getPageNum: function() {
+        var queryMap = this.makeQueryMap();
+        var pageNum = 1;
+        if (queryMap.page !== undefined) {
+          pageNum = parseInt(queryMap.page[0]);
         }
-      });
-
-      //open the lateral panel
-      $('.btn-taxonomies').on('click', function (event) {
-        event.preventDefault();
-        loadManageTaxonomies();
-        $('.cd-panel-2').addClass('is-visible');
-      });
-
-      //close the lateral panel
-      $('.cd-panel-2').on('click', function (event) {
-        if ($(event.target).is('.cd-panel-2') ||
-          $(event.target).is('.cd-panel-close')) {
-          hideTaxonomyPanel();
-          event.preventDefault();
-        }
-      });
-
-      /**
-       * Render resource items in the UI
-       *
-       * @returns {ReactElement} The rendered resource items
-       */
-      var renderListingResources;
-
-      // queryMap is the canonical place to manage query parameters for the UI.
-      // The URL in the browser will be updated with these changes in
-      // refreshFromAPI.
-      var queryMap = {};
-
-      // Controls the loader on the listing page.
-      var pageLoaded = false;
-
-      // Populate queryMap with query string key value pairs.
-      _.each(URI(window.location).query(true), function(v, k) {
-        if (!Array.isArray(v)) {
-          // URI().query(true) will put two or more values with the same
-          // key in an array and not use an array for single values.
-          // Put everything into arrays for consistency's sake.
-          queryMap[k] = [v];
-        } else {
-          queryMap[k] = v;
-        }
-      });
-
-      // This should get updated after the first API call
-      var numPages = 0;
-      var pageNum = 1;
-      if (queryMap.page !== undefined) {
-        pageNum = parseInt(queryMap.page[0]);
-      }
-
+        return pageNum;
+      },
+      getInitialState: function () {
+        return {
+          // empty resources and facetCounts to start with
+          resources: [],
+          facetCounts: {},
+          // Controls the loader on the listing page.
+          pageLoaded: false,
+          allExports: this.props.allExports,
+          sortingOptions: this.props.sortingOptions,
+          // This should get updated after the first API call
+          numPages: 0,
+          // Will be set on refresh
+          selectedFacets: {},
+          selectedMissingFacets: {},
+          // Keep track of resource id so we can lazy load panels.
+          currentResourceId: undefined,
+          // What panels are already loaded
+          loadedPanels: {}
+        };
+      },
+      render: function () {
+        var options = {
+          repoSlug: this.props.repoSlug,
+          allExports: this.state.allExports,
+          sortingOptions: this.state.sortingOptions,
+          loggedInUsername: this.props.loggedInUsername,
+          imageDir: this.props.imageDir,
+          pageSize: this.props.pageSize,
+          openExportsPanel: this.openExportsPanel,
+          openResourcePanel: this.openResourcePanel,
+          updateFacets: this.updateFacets,
+          updateMissingFacets: this.updateMissingFacets,
+          selectedFacets: this.state.selectedFacets,
+          selectedMissingFacets: this.state.selectedMissingFacets,
+          updateSort: this.updateSort,
+          pageNum: this.getPageNum(),
+          numPages: this.state.numPages,
+          updatePage: this.updatePage,
+          loaded: this.state.pageLoaded,
+          resources: this.state.resources,
+          facetCounts: this.state.facetCounts,
+          ref: "listingResources"
+        };
+        return React.createElement(ListingResources.ListingPage, options);
+      },
       /**
        * Clears exports on page. Assumes DELETE to clear on server already
        * happened.
        */
-      var clearExports = function () {
+      clearExports: function () {
         // Clear export links.
-        listingOptions = $.extend({}, listingOptions);
-        listingOptions.allExports = [];
+        this.setState({allExports: []});
 
-        var listingResources = renderListingResources();
-        listingResources.clearSelectedExports();
-      };
-
-      var openExportsPanel = function(exportCount) {
+        // TODO: we shouldn't need a ref here, state should be moved up here
+        this.refs.listingResources.clearSelectedExports();
+      },
+      loadManageTaxonomies: function () {
+        ManageTaxonomies.loader(
+          this.props.repoSlug,
+          $('#taxonomy-component')[0],
+          showConfirmationDialog,
+          showTab,
+          setTabName,
+          this.refreshFromAPI
+        );
+      },
+      openExportsPanel: function (exportCount) {
         $('.cd-panel-exports').addClass('is-visible');
-        Exports.loader(repoSlug, loggedInUsername, clearExports,
-          $("#exports_content")[0]);
+        Exports.loader(
+          this.props.repoSlug,
+          this.props.loggedInUsername,
+          this.clearExports,
+          $("#exports_content")[0]
+        );
         Exports.loadExportsHeader(exportCount, $("#exports_heading")[0]);
-      };
-
+      },
+      getPanelLoaders: function() {
+        return {
+          "tab-1": this.loadResourceTab,
+          "tab-2": this.loadXmlTab,
+          "tab-3": this.loadStaticAssetsTab
+        };
+      },
       /**
        * When called, query search API using query parameters of this URL
        * and update listing with updated resources.
@@ -220,104 +231,79 @@ define('listing',
        * @returns {jQuery.Deferred} A promise that's resolved or rejected when
        * the AJAX call completes and the rerender is triggered.
        */
-      var refreshFromAPI;
+      refreshFromAPI: function() {
+        this.setState({pageLoaded: false});
 
-      // Will be set in refreshFromAPI
-      var selectedFacets;
-      var selectedMissingFacets;
+        var queryMap = this.makeQueryMap();
+        var newQuery = this.makeQueryString(queryMap);
 
-      var loadResourceTab = function(resourceId) {
-        LearningResources.loader(
-          repoSlug,
-          resourceId,
-          refreshFromAPI,
-          closeLearningResourcePanel,
-          $("#tab-1")[0]
-        );
-      };
-
-      var loadXmlTab = function(resourceId) {
-        XmlPanel.loader(repoSlug, resourceId, $("#tab-2")[0]);
-      };
-
-      var loadStaticAssetsTab = function(resourceId) {
-        StaticAssets.loader(repoSlug, resourceId, $("#tab-3")[0]);
-      };
-
-      // Keep track of resource id so we can lazy load panels.
-      var currentResourceId;
-
-      var panelLoaders = {
-        "tab-1": loadResourceTab,
-        "tab-2": loadXmlTab,
-        "tab-3": loadStaticAssetsTab
-      };
-
-      var loadedPanels;
-      var openResourcePanel = function(resourceId) {
-        // Reset loaded panels
-        loadedPanels = {};
-        currentResourceId = resourceId;
-
-        // Load the resource tab
-        showTab("tab-1");
-        loadResourceTab(currentResourceId);
-        loadedPanels["tab-1"] = true;
-
-        $('.cd-panel').addClass('is-visible');
-      };
-
-      _.each(panelLoaders, function(loader, tag) {
-        $("a[href='#" + tag + "']").click(function() {
-          // If tab not already loaded, load it now
-          if (!loadedPanels[tag]) {
-            loader(currentResourceId);
-            loadedPanels[tag] = true;
-          }
-        });
-      });
-
-      refreshFromAPI = function() {
-        pageLoaded = false;
-
-        var newQuery = "?" + URI().search(queryMap).query();
-        if (newQuery === "?") {
-          // Don't put ? in URL if empty
-          History.replaceState(null, document.title, ".");
-          newQuery = "";
-        } else {
-          History.replaceState(null, document.title, newQuery);
-        }
-
+        // Query string for repository page is the same used for the search API
         var url = "/api/v1/repositories/" +
-          listingOptions.repoSlug + "/search/" + newQuery;
+          this.props.repoSlug + "/search/" + newQuery;
 
-        renderListingResources();
-        return $.get(url).then(function(collection) {
-          listingOptions = $.extend({}, listingOptions);
-          listingOptions.resources = collection.results;
-          listingOptions.facetCounts = collection.facet_counts;
-          selectedFacets = collection.selected_facets;
-          selectedMissingFacets = collection.selected_missing_facets;
+        var thiz = this;
+        return $.get(url).then(function (collection) {
+          thiz.setState({
+            resources: collection.results,
+            facetCounts: collection.facet_counts,
+            selectedFacets: collection.selected_facets,
+            selectedMissingFacets: collection.selected_missing_facets
+          });
 
-          numPages = Math.ceil(collection.count / listingOptions.pageSize);
+          var numPages = Math.ceil(collection.count / thiz.props.pageSize);
+          var oldPageNum = thiz.getPageNum();
+          var pageNum = oldPageNum;
           if (pageNum > numPages) {
             pageNum = numPages - 1;
             if (pageNum < 1) {
               pageNum = 1;
             }
           }
-        }).fail(function(error) {
+          thiz.setState({
+            numPages: numPages
+          });
+          if (pageNum !== oldPageNum) {
+            queryMap.page = pageNum;
+            // Update URL string again for different pageNum
+            thiz.updateQuery(queryMap);
+          }
+        }).fail(function (error) {
           // Propagate error
           return $.Deferred().reject(error);
         }).always(function() {
-          pageLoaded = true;
-          renderListingResources();
+          thiz.setState({pageLoaded: true});
         });
-      };
+      },
+      loadResourceTab: function (resourceId) {
+        LearningResources.loader(
+          this.props.repoSlug,
+          resourceId,
+          this.refreshFromAPI,
+          closeLearningResourcePanel,
+          $("#tab-1")[0]
+        );
+      },
+      loadXmlTab: function (resourceId) {
+        XmlPanel.loader(this.props.repoSlug, resourceId, $("#tab-2")[0]);
+      },
+      loadStaticAssetsTab: function (resourceId) {
+        StaticAssets.loader(this.props.repoSlug, resourceId, $("#tab-3")[0]);
+      },
+      openResourcePanel: function (resourceId) {
+        // Reset loaded panels
+        var loadedPanels = {};
+        this.setState({currentResourceId: resourceId});
 
-      var updateFacetParam = function(param, selected) {
-        queryMap = $.extend({}, queryMap);
+        // Load the resource tab
+        showTab("tab-1");
+        this.loadResourceTab(resourceId);
+        loadedPanels["tab-1"] = true;
+        this.setState({loadedPanels: loadedPanels});
+
+        $('.cd-panel').addClass('is-visible');
+      },
+      updateFacetParam: function (param, selected) {
+        var queryMap = this.makeQueryMap();
         queryMap.page = undefined;
 
         if (!queryMap.selected_facets) {
@@ -326,18 +312,18 @@ define('listing',
 
         // Remove facet. If selected we'll add it back again with a push().
         queryMap.selected_facets = _.filter(
-          queryMap.selected_facets, function(facet) {
+          queryMap.selected_facets, function (facet) {
             return facet !== param;
           }
         );
 
         if (selected) {
-          queryMap.selected_facets.push(param);
+          queryMap.selected_facets = queryMap.selected_facets.concat(param);
         }
 
-        return refreshFromAPI();
-      };
-
+        this.updateQuery(queryMap);
+        return this.refreshFromAPI();
+      },
       /**
        * Update queryMap with updated facet information, then refresh from API.
        *
@@ -348,18 +334,16 @@ define('listing',
        * @returns {jQuery.Deferred} Promise which is resolved or rejected after
        * refresh occurs.
        */
-      var updateFacets = function(facetId, valueId, selected) {
+      updateFacets: function (facetId, valueId, selected) {
         var param = facetId + "_exact:" + valueId;
 
-        return updateFacetParam(param, selected);
-      };
-
-      var updateMissingFacets = function(facetId, selected) {
+        return this.updateFacetParam(param, selected);
+      },
+      updateMissingFacets: function (facetId, selected) {
         var param = "_missing_:" + facetId + "_exact";
 
-        return updateFacetParam(param, selected);
-      };
-
+        return this.updateFacetParam(param, selected);
+      },
       /**
        * Update sorting and refresh from API.
        *
@@ -367,46 +351,38 @@ define('listing',
        * @return {jQuery.Deferred} A promise which is resolved or rejected after
        * refresh has occurred.
        */
-      var updateSort = function(value) {
-        queryMap = $.extend({}, queryMap);
+      updateSort: function (value) {
+        var queryMap = this.makeQueryMap();
         queryMap.sortby = value;
 
-        listingOptions = $.extend({}, listingOptions);
-        var allOptions = listingOptions.sortingOptions.all.concat([
-          listingOptions.sortingOptions.current
+        var sortingOptions = this.state.sortingOptions;
+        var allOptions = sortingOptions.all.concat([
+          sortingOptions.current
         ]);
-        var current = _.filter(allOptions, function(pair) {
+        var current = _.filter(allOptions, function (pair) {
           return pair[0] === value;
         });
-        var all = _.filter(allOptions, function(pair) {
+        var all = _.filter(allOptions, function (pair) {
           return pair[0] !== value;
         });
-        listingOptions.sortingOptions.all = all;
-        listingOptions.sortingOptions.current = current[0];
+        this.setState({
+          sortingOptions: {
+            all: all,
+            current: current[0]
+          }
+        });
 
-        refreshFromAPI();
-      };
-
-      /**
-       * Rerender listing resources
-       * @returns {ReactComponent}
-       */
-      renderListingResources = function() {
-        return ListingResources.loader(listingOptions,
-          container, openExportsPanel, openResourcePanel,
-          updateFacets, updateMissingFacets,
-          selectedFacets, selectedMissingFacets, updateSort, pageNum, numPages,
-          updatePage, pageLoaded
-        );
-      };
-
+        this.updateQuery(queryMap);
+        return this.refreshFromAPI();
+      },
       /**
        * Update search parameter then refresh from API.
        *
        * @param search {String} The search phrase
        * @returns {jQuery.Deferred} Promise which evalutes after refresh occurs.
        */
-      var updateSearch = function (search) {
+      updateSearch: function (search) {
+        var queryMap = this.makeQueryMap();
         queryMap.page = undefined;
         if (search !== '') {
           queryMap.q = [search];
@@ -417,156 +393,247 @@ define('listing',
         // clear facets
         queryMap.selected_facets = undefined;
 
-        return refreshFromAPI();
-      };
-
-      // If search is executed update query parameter and refresh from API.
-      $("#search_button").click(function(e) {
-        e.preventDefault();
-
-        var search = $("#id_q").val();
-        updateSearch(search);
-      });
-
-      // Close exports panel.
-      $('.cd-panel-exports').on('click', function (event) {
-        if ($(event.target).is('.cd-panel-exports') ||
-          $(event.target).is('.cd-panel-close')) {
-          $('.cd-panel-exports').removeClass('is-visible');
-          event.preventDefault();
-        }
-      });
-
-      //open the lateral panel for members
-      $('.btn-members').on('click', function (event) {
-        event.preventDefault();
-        //remove any alert
-        $('#members-alert').empty();
-        //reset the form values
-        resetUserGroupForm();
-        //make panel visible
-        $('.cd-panel-members').addClass('is-visible');
-        //retrieve all the members
-        showUpdateAllMembers();
-        //
-      });
-      //close the lateral panel for members
-      $('.cd-panel-members').on('click', function (event) {
-        if ($(event.target).is('.cd-panel-members') ||
-          $(event.target).is('.cd-panel-close')) {
-          $('.cd-panel-members').removeClass('is-visible');
-          event.preventDefault();
-        }
-      });
-      //add button for the members
-      $(document).on('click', '.cd-panel-members-add', function () {
-        var url = $('.cd-panel-members').data('members-url');
-        var username = $('input[name=\'members-username\']').val();
-        var groupType = $('select[name=\'members-group_type\']').val();
-        // /api/v1/repositories/my-rep/members/groups/<group_type>/users/
-        url += 'groups/' + groupType + '/users/';
-        //test that username is not an email
-        if (isEmail(username)) {
-          var message = 'Please type only your username before the @';
-          showMembersAlert(message, 'warning');
-          return;
-        }
-        var email = username + EMAIL_EXTENSION;
-        if (!isEmail(email)) {
-          var emailMessage = '<strong>' + email +
-            '</strong> does not seem to be a valid email';
-          showMembersAlert(emailMessage, 'danger');
-          return;
-        }
-        $.ajax({
-          url: url,
-          type: 'POST',
-          data: {username: username}
-        })
-        .then(function() {
-          //retrieve the members lists
-          return showUpdateAllMembers();
-        })
-        .then(function () {
-          //reset the values
-          resetUserGroupForm();
-          //show alert
-          var message = '<strong>' + email +
-            '</strong> added to group <strong>' +
-            formatGroupName(groupType) + '</strong>';
-          showMembersAlert(message);
-        })
-        .fail(function (data) {
-          //show alert
-          var message = 'Error adding user ' + email +
-            ' to group ' + formatGroupName(groupType);
-          if (data && data.responseJSON && data.responseJSON.username) {
-            message = message + '<br>' + data.responseJSON.username[0];
-          }
-          showMembersAlert(message, 'danger');
-        });
-      });
-      //remove button for the members
-      $(document).on('click', '.cd-panel-members-remove', function () {
-        var url = $('.cd-panel-members').data('members-url');
-        var username = $(this).data('username');
-        var groupType = $(this).data('group_type');
-        var email = username + EMAIL_EXTENSION;
-        // /api/v1/repositories/my-rep/members/groups/<group_type>/users/<username>/
-        url += 'groups/' + groupType + '/users/' + username + '/';
-        $.ajax({
-          url: url,
-          type: 'DELETE'
-        })
-        .then(function() {
-          //retrieve the members lists
-          return showUpdateAllMembers();
-        })
-        .then(function () {
-          //show alert
-          var message = '<strong>' + email +
-            '</strong> deleted from group <strong>' +
-            formatGroupName(groupType) + '</strong>';
-          showMembersAlert(message);
-        })
-        .fail(function (data) {
-          //show alert
-          var message = 'Error deleting user <strong>' +
-            email + '</strong> from group <strong>' +
-            formatGroupName(groupType) + '</strong>';
-          if (data && data.responseJSON && data.responseJSON.detail) {
-            message += '<br>' + data.responseJSON.detail;
-          }
-          showMembersAlert(message, 'danger');
-        });
-      });
-
+        this.updateQuery(queryMap);
+        return this.refreshFromAPI();
+      },
       /**
        * Update page number and refresh from API.
        * @param newPageNum {Number} New page number
        * @return {jQuery.Deferred} Promise which resolves or rejects after
        * refresh has occurred.
        */
-      var updatePage = function(newPageNum) {
+      updatePage: function (newPageNum) {
+        var queryMap = this.makeQueryMap();
         queryMap.page = [newPageNum.toString()];
-        pageNum = parseInt(newPageNum);
 
-        return refreshFromAPI();
+        this.updateQuery(queryMap);
+        return this.refreshFromAPI();
+      },
+
+      componentDidMount: function () {
+        CSRF.setupCSRF();
+
+        var thiz = this;
+
+        $('[data-toggle=popover]').popover();
+        //Close panels on escape keypress
+        $(document).keyup(function (event) {
+          if (event.keyCode === 27) { // escape key maps to keycode `27`
+            closeLearningResourcePanel();
+            if ($('.cd-panel-2').hasClass('is-visible')) {
+              hideTaxonomyPanel();
+            }
+            if ($('.cd-panel-exports').hasClass('is-visible')) {
+              $('.cd-panel-exports').removeClass('is-visible');
+            }
+            if ($('.cd-panel-members').hasClass('is-visible')) {
+              $('.cd-panel-members').removeClass('is-visible');
+            }
+            event.preventDefault();
+          }
+        });
+
+        //close the lateral panel
+        $('.cd-panel').on('click', function (event) {
+          if ($(event.target).is('.cd-panel') ||
+            $(event.target).is('.cd-panel-close')) {
+            closeLearningResourcePanel();
+            event.preventDefault();
+          }
+        });
+
+        //open the lateral panel
+        $('.btn-taxonomies').on('click', function (event) {
+          event.preventDefault();
+          thiz.loadManageTaxonomies();
+          $('.cd-panel-2').addClass('is-visible');
+        });
+
+        //close the lateral panel
+        $('.cd-panel-2').on('click', function (event) {
+          if ($(event.target).is('.cd-panel-2') ||
+            $(event.target).is('.cd-panel-close')) {
+            hideTaxonomyPanel();
+            event.preventDefault();
+          }
+        });
+
+        _.each(this.getPanelLoaders(), function (loader, tag) {
+          $("a[href='#" + tag + "']").click(function () {
+            // If tab not already loaded, load it now
+            if (!thiz.state.loadedPanels[tag]) {
+              loader(thiz.state.currentResourceId);
+              var loadedPanels = $.extend({}, thiz.state.loadedPanels);
+              loadedPanels[tag] = true;
+              thiz.setState({
+                loadedPanels: loadedPanels
+              });
+            }
+          });
+        });
+
+        // If search is executed update query parameter and refresh from API.
+        $("#search_button").click(function (e) {
+          e.preventDefault();
+
+          var search = $("#id_q").val();
+          thiz.updateSearch(search);
+        });
+
+        // Close exports panel.
+        $('.cd-panel-exports').on('click', function (event) {
+          if ($(event.target).is('.cd-panel-exports') ||
+            $(event.target).is('.cd-panel-close')) {
+            $('.cd-panel-exports').removeClass('is-visible');
+            event.preventDefault();
+          }
+        });
+
+        //open the lateral panel for members
+        $('.btn-members').on('click', function (event) {
+          event.preventDefault();
+          //remove any alert
+          $('#members-alert').empty();
+          //reset the form values
+          resetUserGroupForm();
+          //make panel visible
+          $('.cd-panel-members').addClass('is-visible');
+          //retrieve all the members
+          showUpdateAllMembers();
+        });
+
+        //close the lateral panel for members
+        $('.cd-panel-members').on('click', function (event) {
+          if ($(event.target).is('.cd-panel-members') ||
+            $(event.target).is('.cd-panel-close')) {
+            $('.cd-panel-members').removeClass('is-visible');
+            event.preventDefault();
+          }
+        });
+
+        //add button for the members
+        $(document).on('click', '.cd-panel-members-add', function () {
+          var url = $('.cd-panel-members').data('members-url');
+          var username = $('input[name=\'members-username\']').val();
+          var groupType = $('select[name=\'members-group_type\']').val();
+          // /api/v1/repositories/my-rep/members/groups/<group_type>/users/
+          url += 'groups/' + groupType + '/users/';
+          //test that username is not an email
+          if (isEmail(username)) {
+            var message = 'Please type only your username before the @';
+            showMembersAlert(message, 'warning');
+            return;
+          }
+          var email = username + EMAIL_EXTENSION;
+          if (!isEmail(email)) {
+            var emailMessage = '<strong>' + email +
+              '</strong> does not seem to be a valid email';
+            showMembersAlert(emailMessage, 'danger');
+            return;
+          }
+          $.ajax({
+            url: url,
+            type: 'POST',
+            data: {username: username}
+          })
+            .then(function () {
+              //retrieve the members lists
+              return showUpdateAllMembers();
+            })
+            .then(function () {
+              //reset the values
+              resetUserGroupForm();
+              //show alert
+              var message = '<strong>' + email +
+                '</strong> added to group <strong>' +
+                formatGroupName(groupType) + '</strong>';
+              showMembersAlert(message);
+            })
+            .fail(function (data) {
+              //show alert
+              var message = 'Error adding user ' + email +
+                ' to group ' + formatGroupName(groupType);
+              if (data && data.responseJSON && data.responseJSON.username) {
+                message = message + '<br>' + data.responseJSON.username[0];
+              }
+              showMembersAlert(message, 'danger');
+            });
+        });
+
+        //remove button for the members
+        $(document).on('click', '.cd-panel-members-remove', function () {
+          var url = $('.cd-panel-members').data('members-url');
+          var username = $(this).data('username');
+          var groupType = $(this).data('group_type');
+          var email = username + EMAIL_EXTENSION;
+          // /api/v1/repositories/my-rep/members/groups/<group_type>/users/<username>/
+          url += 'groups/' + groupType + '/users/' + username + '/';
+          $.ajax({
+            url: url,
+            type: 'DELETE'
+          })
+            .then(function () {
+              //retrieve the members lists
+              return showUpdateAllMembers();
+            })
+            .then(function () {
+              //show alert
+              var message = '<strong>' + email +
+                '</strong> deleted from group <strong>' +
+                formatGroupName(groupType) + '</strong>';
+              showMembersAlert(message);
+            })
+            .fail(function (data) {
+              //show alert
+              var message = 'Error deleting user <strong>' +
+                email + '</strong> from group <strong>' +
+                formatGroupName(groupType) + '</strong>';
+              if (data && data.responseJSON && data.responseJSON.detail) {
+                message += '<br>' + data.responseJSON.detail;
+              }
+              showMembersAlert(message, 'danger');
+            });
+        });
+
+        // Initial refresh to populate page.
+        thiz.refreshFromAPI();
+      }
+    });
+
+    var updateQueryString = function(newQuery) {
+      if (newQuery.length === 0) {
+        History.replaceState(null, document.title, ".");
+      } else {
+        History.replaceState(null, document.title, newQuery);
+      }
+    };
+
+    var getQueryString = function() {
+      return URI(window.location).search();
+    };
+
+    var loader = function (listingOptions, container) {
+      var options = {
+        allExports: listingOptions.allExports,
+        sortingOptions: listingOptions.sortingOptions,
+        imageDir: listingOptions.imageDir,
+        pageSize: listingOptions.pageSize,
+        repoSlug: listingOptions.repoSlug,
+        loggedInUsername: listingOptions.loggedInUsername,
+        updateQueryString: updateQueryString,
+        getQueryString: getQueryString
       };
 
-      var showConfirmationDialog = function(options) {
-        var container = $("#confirmation-container")[0];
-        Utils.showConfirmationDialog(
-          options,
-          container
-        );
-      };
-
-      // Initial refresh to populate page.
-      refreshFromAPI();
+      React.render(
+        React.createElement(ListingContainer, options),
+        container
+      );
     };
 
     return {
+      ListingContainer: ListingContainer,
+      isEmail: isEmail,
+      formatGroupName: formatGroupName,
       loader: loader
     };
   });

--- a/ui/static/ui/js/listing.js
+++ b/ui/static/ui/js/listing.js
@@ -256,7 +256,6 @@ define('listing',
 
         renderListingResources();
         return $.get(url).then(function(collection) {
-          pageLoaded = true;
           listingOptions = $.extend({}, listingOptions);
           listingOptions.resources = collection.results;
           listingOptions.facetCounts = collection.facet_counts;
@@ -270,13 +269,12 @@ define('listing',
               pageNum = 1;
             }
           }
-
-          renderListingResources();
         }).fail(function(error) {
-          pageLoaded = true;
-
           // Propagate error
           return $.Deferred().reject(error);
+        }).always(function() {
+          pageLoaded = true;
+          renderListingResources();
         });
       };
 

--- a/ui/static/ui/js/manage_taxonomies.jsx
+++ b/ui/static/ui/js/manage_taxonomies.jsx
@@ -118,6 +118,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         label: this.state.label,
         weight: this.props.term.weight
       };
+      thiz.props.setLoadedState(false);
       $.ajax({
         type: 'PATCH',
         url: API_ROOT_VOCAB_URL,
@@ -127,10 +128,12 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         thiz.setState({
           errorMessage: 'Unable to update term'
         });
-      }).done(function(term) {
+      }).then(function(term) {
         thiz.resetUtilityFeatures();
         thiz.props.updateTerm(thiz.props.vocabulary.id, term);
         thiz.props.refreshFromAPI();
+      }).always(function() {
+        thiz.props.setLoadedState(true);
       });
     },
     confirmedDeleteResponse: function(success) {
@@ -139,6 +142,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         var API_ROOT_VOCAB_URL = '/api/v1/repositories/' + this.props.repoSlug +
         '/vocabularies/' + this.props.vocabulary.slug + '/terms/' +
         this.props.term.slug + "/";
+        thiz.props.setLoadedState(false);
         $.ajax({
           type: 'DELETE',
           url: API_ROOT_VOCAB_URL,
@@ -147,9 +151,11 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           thiz.setState({
             errorMessage: 'Unable to delete term.'
           });
-        }).done(function() {
+        }).then(function() {
           thiz.props.deleteTerm(thiz.props.vocabulary.id, thiz.props.term);
           thiz.props.refreshFromAPI();
+        }).always(function() {
+          thiz.props.setLoadedState(true);
         });
       }
     }
@@ -169,6 +175,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           key={term.id}
           renderConfirmationDialog={thiz.props.renderConfirmationDialog}
           refreshFromAPI={thiz.props.refreshFromAPI}
+          setLoadedState={thiz.props.setLoadedState}
           />;
       });
 
@@ -232,6 +239,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
     confirmedDeleteResponse: function(success) {
       var thiz = this;
       if (success) {
+        this.props.setLoadedState(false);
         var vocab = this.props.vocabulary;
         var API_ROOT_VOCAB_URL = '/api/v1/repositories/' + this.props.repoSlug +
           '/vocabularies/' + vocab.slug + '/';
@@ -245,6 +253,8 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           thiz.props.deleteVocabulary(vocab.id);
 
           thiz.props.refreshFromAPI();
+        }).always(function() {
+          thiz.props.setLoadedState(true);
         });
       }
     },
@@ -266,6 +276,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
       var thiz = this;
       var API_ROOT_VOCAB_URL = '/api/v1/repositories/' + this.props.repoSlug +
         '/vocabularies/';
+      this.props.setLoadedState(false);
       $.ajax({
           type: "POST",
           url: API_ROOT_VOCAB_URL + this.props.vocabulary.slug + "/terms/",
@@ -276,20 +287,22 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           contentType: "application/json; charset=utf-8"
         }
       ).fail(function() {
-          thiz.props.reportMessage({
-            error: "Error occurred while adding new term."
-          });
-        })
-      .then(function(newTerm) {
-          thiz.props.addTerm(thiz.props.vocabulary.id, newTerm);
-          thiz.setState({
-            newTermLabel: null
-          });
-
-          // clear errors
-          thiz.props.reportMessage(null);
-          thiz.props.refreshFromAPI();
+        thiz.props.reportMessage({
+          error: "Error occurred while adding new term."
         });
+      })
+      .then(function(newTerm) {
+        thiz.props.addTerm(thiz.props.vocabulary.id, newTerm);
+        thiz.setState({
+          newTermLabel: null
+        });
+
+        // clear errors
+        thiz.props.reportMessage(null);
+        thiz.props.refreshFromAPI();
+      }).always(function() {
+        thiz.props.setLoadedState(true);
+      });
     },
     getInitialState: function() {
       return {
@@ -316,6 +329,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           addTerm={thiz.props.addTerm}
           renderConfirmationDialog={thiz.props.renderConfirmationDialog}
           refreshFromAPI={thiz.props.refreshFromAPI}
+          setLoadedState={thiz.props.setLoadedState}
           />;
       });
       return <div className="panel-group lore-panel-group">
@@ -399,6 +413,8 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         learning_resource_types: this.state.learningResourceTypes,
         multi_terms: this.state.multiTerms
       };
+
+      thiz.props.setLoadedState(false);
 
       // User wants to submit the form. First we need to see if any
       // resource term links would be deleted by this action. If so we need
@@ -506,6 +522,8 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
           }
           thiz.props.reportMessage({error: error});
         }
+      }).always(function() {
+        thiz.props.setLoadedState(true);
       });
     },
     isEditModeOpen: function() {
@@ -755,8 +773,9 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
         </ul>
         <div className="tab-content drawer-tab-content">
           <div className="tab-pane active" id="tab-taxonomies">
-            <ReactOverlayLoader loaded={this.state.loaded}
-                                hideChildrenOnLoad={true}>
+            <ReactOverlayLoader
+              loaded={this.state.loaded}
+              hideChildrenOnLoad={!this.state.showChildrenOnLoad}>
             <AddTermsComponent
               deleteTerm={this.deleteTerm}
               updateTerm={this.updateTerm}
@@ -769,12 +788,13 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
               addTerm={this.addTerm}
               message={this.state.termsMessage}
               reportMessage={this.termsReport}
+              setLoadedState={this.setLoadedState}
               />
             </ReactOverlayLoader>
           </div>
           <div className="tab-pane drawer-tab-content" id="tab-vocab">
             <ReactOverlayLoader loaded={this.state.loaded}
-              hideChildrenOnLoad={true}>
+              hideChildrenOnLoad={!this.state.showChildrenOnLoad}>
             <AddVocabulary
               editVocabulary={this.editVocabulary}
               updateParent={this.addOrUpdateVocabulary}
@@ -785,6 +805,7 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
               refreshFromAPI={this.props.refreshFromAPI}
               message={this.state.vocabMessage}
               reportMessage={this.vocabReport}
+              setLoadedState={this.setLoadedState}
               />
               </ReactOverlayLoader>
           </div>
@@ -798,10 +819,16 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
     termsReport: function(message) {
       this.setState({termsMessage: message});
     },
+    setLoadedState: function(loaded) {
+      this.setState({loaded: loaded});
+    },
     componentDidMount: function() {
       var thiz = this;
 
-      this.setState({loaded: false});
+      this.setState({
+        loaded: false,
+        showChildrenOnLoad: false
+      });
       Utils.getCollection("/api/v1/learning_resource_types/").then(
         function(learningResourceTypes) {
         if (!thiz.isMounted()) {
@@ -819,13 +846,15 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
             }
 
             thiz.setState({
-              vocabularies: vocabularies,
-              loaded: true
+              vocabularies: vocabularies
             });
           }
         );
-      }).fail(function() {
-        thiz.setState({loaded: true});
+      }).always(function() {
+        thiz.setState({
+          loaded: true,
+          showChildrenOnLoad: true
+        });
       });
     }
   });

--- a/ui/static/ui/js/manage_taxonomies.jsx
+++ b/ui/static/ui/js/manage_taxonomies.jsx
@@ -60,7 +60,8 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
      * If user selects edit button then open edit mode
      * Else call api to update term.
      */
-    editTerm: function() {
+    editTerm: function(e) {
+      e.preventDefault();
       this.setState({
         formatActionState: 'edit',
         label: this.props.term.label
@@ -83,7 +84,8 @@ define('manage_taxonomies', ['react', 'lodash', 'jquery', 'uri',
       // user is in edit mode. Cancel edit if user presses cross icon.
       this.resetUtilityFeatures();
     },
-    deleteTerm: function() {
+    deleteTerm: function(e) {
+      e.preventDefault();
       var options = {
         actionButtonName: "Delete",
         actionButtonClass: "btn btn-danger btn-ok",

--- a/ui/static/ui/js/utils.jsx
+++ b/ui/static/ui/js/utils.jsx
@@ -336,7 +336,7 @@ define("utils", ["jquery", "lodash", "react", "react_infinite", "spin",
       if (this.isMounted() && !this.props.loaded) {
         var target = React.findDOMNode(this.refs.loader);
 
-        var spinner = new Spinner();
+        var spinner = new Spinner({zIndex: 0});
         spinner.spin(target);
       }
     },

--- a/ui/templates/includes/resource_panel.html
+++ b/ui/templates/includes/resource_panel.html
@@ -12,7 +12,7 @@
           </a>
         </li>
         <li>
-          <a href="#tab-2" data-toggle="tab" aria-expanded="true">
+          <a href="#tab-2" data-toggle="tab" aria-expanded="false">
             <span class="hidden-xs">XML</span>
           </a>
         </li>

--- a/ui/views.py
+++ b/ui/views.py
@@ -36,7 +36,6 @@ from learningresources.models import (
 from rest.pagination import LorePagination
 from roles.permissions import RepoPermission
 from search.sorting import LoreSortingFields
-from taxonomy.models import Vocabulary, Term
 from ui.forms import UploadForm, RepositoryForm
 
 log = logging.getLogger(__name__)
@@ -121,60 +120,6 @@ def create_repo(request):
         "create_repo.html",
         {"form": form},
     )
-
-
-def get_vocabularies(facets):
-    """
-    Parse facet information for the template.
-    It will return a dictionary that looks like this:
-
-    {
-        (u'13', u'difficulty'): [(38, u'medium', 23), (17, u'hard', 19)],
-        (u'15', u'prerequisite'): [(44, u'yes', 23)]
-    }
-
-    The keys are tuples with Vocabulary ID and name for the key,
-    and a list of tuples containing id, label, and count for the terms.
-
-    This is for ease-of-use in the template, where the integer primary keys
-    are used for search links and the names/labels are used for display.
-
-    Args:
-        facets (dict): facet ID with terms & term counts
-    Returns:
-        vocabularies (dict): dict of vocab info to term info
-    """
-
-    if "fields" not in facets:
-        return {}
-    vocab_ids = []
-    term_ids = []
-    for vocab_id, counts in facets["fields"].items():
-        if not vocab_id.isdigit():
-            continue
-        vocab_ids.append(int(vocab_id))
-        for term_id, count in counts:
-            term_ids.append(term_id)
-
-    vocabs = {
-        x: y for x, y in Vocabulary.objects.filter(
-            id__in=vocab_ids).values_list('id', 'name')
-    }
-    terms = {
-        x: y for x, y in Term.objects.filter(
-            id__in=term_ids).values_list('id', 'label')
-    }
-    vocabularies = {}
-    for vocabulary_id, term_data in facets["fields"].items():
-        if not vocabulary_id.isdigit():
-            continue
-        vocab = (vocabulary_id, vocabs[int(vocabulary_id)])
-        vocabularies[vocab] = []
-        for t_id, count in term_data:
-            vocabularies[vocab].append((t_id, terms[int(t_id)], count))
-        # By default, sort alphabetically.
-        vocabularies[vocab].sort(key=lambda x: x[1])
-    return vocabularies
 
 
 @statsd.timer('lore.repository_view')


### PR DESCRIPTION
Release v0.13.0
- [x] Refactored listing code for testing
  [George Schneeloch](gschneel@mit.edu)
- [x] Implemented lazy loading for resource tab
  [George Schneeloch](gschneel@mit.edu)
- [x] Added custom slugify function to allow any name for Repo, Vocab, Term
  [Giovanni Di Milia](gdimilia@mit.edu)
- [x] Fixed index mapping of terms and vocabularies
  [George Schneeloch](gschneel@mit.edu)
- [x] Set Elasticsearch log level higher during testing
  [George Schneeloch](gschneel@mit.edu)
- [x] Set Spinner zIndex to 0 to not have it float above everything else
  [George Schneeloch](gschneel@mit.edu)
- [x] Added loader on save
  [George Schneeloch](gschneel@mit.edu)
- [x] Removed unused functions
  [George Schneeloch](gschneel@mit.edu)
- [x] Fixed link click behavior for term edit and delete
  [George Schneeloch](gschneel@mit.edu)
