### PR TITLE
Fixed double resource import bug

### DIFF
--- a/importer/api/__init__.py
+++ b/importer/api/__init__.py
@@ -144,6 +144,19 @@ def import_course(bundle, repo_id, user_id, static_dir):
     return course
 
 
+def is_leaf_tag(tag):
+    """
+    Should we look for resources within elements with this tag?
+
+    Args:
+        tag (unicode): Element tag
+    Returns:
+        bool: Whether tag is leaf tag
+    """
+    return tag in {'video', 'html', 'problem', 'discussion'}
+
+
+# pylint: disable=too-many-branches
 def import_children(course, element, parent, parent_dpath):
     """
     Create LearningResource instances for each element
@@ -230,6 +243,10 @@ def import_children(course, element, parent, parent_dpath):
         ]
     )
 
-    for child in element.getchildren():
-        if child.tag in DESCRIPTOR_TAGS:
-            import_children(course, child, resource, dpath)
+    # Try to protect against bad data, specifically <problem><problem>...
+    # imports. The two tags will still appear in content_xml but there will
+    # be only one resource for the outer one.
+    if not is_leaf_tag(element.tag):
+        for child in element.getchildren():
+            if child.tag in DESCRIPTOR_TAGS:
+                import_children(course, child, resource, dpath)


### PR DESCRIPTION
Fixes part of #814. In that issue there are two `<problem>` tags, one nested in the other. The inner resource has no url_name so its preview link would be broken. This PR prevents the second problem tag from being imported (it's still present in the content_xml)
