### PR TITLE
Release 0.14.1

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,13 @@
 Release Notes
 -------------
 
+Version 0.14.1
+==============
+
+- Made ``[requires.io]`` dependency update.
+- Added manual test plan.
+- Made changes to accommodate Docker 1.9.0.
+
 Version 0.14.0
 ==============
 

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -15,7 +15,7 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 import yaml
 
-VERSION = '0.14.0'
+VERSION = '0.14.1'
 
 CONFIG_PATHS = [
     os.environ.get('LORE_CONFIG', ''),


### PR DESCRIPTION
Release v0.14.1
- Made `requires.io` dependency update.
- Added manual test plan.
- Made changes to accommodate Docker 1.9.0.
