### PR TITLE
rc/0.15.0

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,13 @@
 Release Notes
 -------------
 
+Version 0.15.0
+==============
+
+- Added sorting by relevance ``(_score)``.
+- Fixed requests installation.
+- Fixed new pylint 1.5.0 violations.
+
 Version 0.14.1
 ==============
 

--- a/lore/settings.py
+++ b/lore/settings.py
@@ -15,7 +15,7 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 import yaml
 
-VERSION = '0.14.1'
+VERSION = '0.15.0'
 
 CONFIG_PATHS = [
     os.environ.get('LORE_CONFIG', ''),


### PR DESCRIPTION
Version 0.15.0
- Added sorting by relevance `(_score)`.
- Fixed requests installation.
- Fixed new pylint 1.5.0 violations.
